### PR TITLE
github.com/near/neps/pull/141 is outdated

### DIFF
--- a/specs/Standards/Tokens/FungibleTokenCore.md
+++ b/specs/Standards/Tokens/FungibleTokenCore.md
@@ -1,4 +1,4 @@
-# Fungible Token ([NEP-141](https://github.com/near/NEPs/issues/141))
+# Fungible Token ([NEP-141](https://github.com/near/NEPs/blob/master/specs/Standards/Tokens/FungibleTokenCore.md))
 
 Version `1.0.0`
 


### PR DESCRIPTION
can confuse newcomers. Eugene could also update what's at http://github.com/near/neps/pull/141 to reflect the new standard