### PR TITLE
Additions: `nft_holder` to get the holder of token; `nft_token_metadata` and `nft_token_uri` to get token metadata

### DIFF
--- a/specs/Standards/NonFungibleToken/Core.md
+++ b/specs/Standards/NonFungibleToken/Core.md
@@ -130,6 +130,11 @@ function nft_transfer_call(
 
 // Returns the token with the given `token_id` or `null` if no such token.
 function nft_token(token_id: string): Token|null {}
+
+// Returns the holder of the token with the given `token_id`. In the core,
+// the holder of the token is identical to the owner of the token, but this
+// method will be expanded on in further standards.
+function nft_holder(token_id: string): String|null {}
 ```
 
 The following behavior is required, but contract authors may name this function something other than the conventional `nft_resolve_transfer` used here.
@@ -203,4 +208,3 @@ function nft_on_transfer(
   [gas]: https://docs.near.org/docs/concepts/gas
   [Metadata]: Metadata.md
   [Approval Management]: ApprovalManagement.md
-

--- a/specs/Standards/NonFungibleToken/Metadata.md
+++ b/specs/Standards/NonFungibleToken/Metadata.md
@@ -50,10 +50,16 @@ type TokenMetadata = {
 }
 ```
 
-A new function MUST be supported on the NFT contract:
+Three new functions MUST be supported on the NFT contract:
 
 ```ts
+// Get the metadata for the NFT contract.
 function nft_metadata(): NFTContractMetadata {}
+// Get the on-chain metadata for the token with with `token_id`.
+function nft_token_metadata(token_id: string): TokenMetadata {}
+// Get the URI (preferably of a decentralized storage platform) where the token metadata
+// is stored.
+function nft_token_uri(token_id: string): String {}
 ```
 
 A new attribute MUST be added to each `Token` struct:


### PR DESCRIPTION
Justification for additions:

The present core and metadata standard are inflexible. They assume that `nft_token`, which gets all information about a token, will correctly obtain data that may require more complexity than a simple lookup. 

Obtaining information about 
1. Who holds the token 
2. What metadata content is related to the token

are likely to be some of the most commonly used operations on NFT contracts, and should be formalized so that they may be built upon reliably in the NFT contract ecosystem. 