### PR TITLE
standards/nft/core: fix approval_id type

### DIFF
--- a/specs/Standards/NonFungibleToken/Core.md
+++ b/specs/Standards/NonFungibleToken/Core.md
@@ -118,7 +118,7 @@ function nft_transfer(
 function nft_transfer_call(
   receiver_id: string,
   token_id: string,
-  approval_id: string|null,
+  approval_id: number|null,
   memo: string|null,
   msg: string,
 ): Promise {}
@@ -197,6 +197,10 @@ function nft_on_transfer(
   msg: string,
 ): Promise<boolean>;
 ```
+
+## Errata
+
+* **2021-07-16**: updated `nft_transfer_call` argument `approval_id` to be type `number|null` instead of `string|null`. As stated, approval IDs are not expected to exceed the JSON limit of 2^53.
 
   [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
   [storage staking]: https://docs.near.org/docs/concepts/storage-staking


### PR DESCRIPTION
Also, add Errata section and explain update