### PR TITLE
Fungible Token Minting Standard

### DIFF
--- a/specs/Standards/FungibleToken/Core.md
+++ b/specs/Standards/FungibleToken/Core.md
@@ -181,7 +181,7 @@ Altogether then, Alice may take two steps, though the first may be a background 
 
 **Interface**:
 
-```javascript
+```ts
 /************************************/
 /* CHANGE METHODS on fungible token */
 /************************************/
@@ -243,7 +243,7 @@ function ft_transfer_call(
 /****************************************/
 
 // This function is implemented on the receving contract.
-// As mentioned, the `msg` argument contains information necessary for the receiving contract to know how to process the request. This may include method names and/or arguments. 
+// As mentioned, the `msg` argument contains information necessary for the receiving contract to know how to process the request. This may include method names and/or arguments.
 // Returns a value, or a promise which resolves with a value. The value is the
 // number of unused tokens in string form. For instance, if `amount` is 10 but only 9 are
 // needed, it will return "1".

--- a/specs/Standards/FungibleToken/Minting.md
+++ b/specs/Standards/FungibleToken/Minting.md
@@ -26,7 +26,7 @@ These tools will usually check the first transaction. In case of NEAR Wallet it 
 // Smart contract can do additional check or validation about who can call this
 // function or under what circumstances.
 // Requirements:
-// * Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes
+// * Caller of the method MUST attach a deposit of 1 yoctoⓃ for security purposes
 //
 // Arguments:
 // * `receiver_id`: the valid NEAR account receiving the fungible tokens.

--- a/specs/Standards/FungibleToken/Minting.md
+++ b/specs/Standards/FungibleToken/Minting.md
@@ -1,0 +1,44 @@
+# Fungible Token Minting
+
+Version `1.0.0`
+
+## Summary
+[summary]: #summary
+
+An interface for a fungible token minting, which is usually a part of a token lifecycle,
+
+## Motivation
+
+Token minting can be triggered by other smart contracts. Hence we need a standard interface for minting.
+
+In a minting life cycle, token will be firstly minted and then transferred. Following scenarios are possible:
+* user can mint tokens for himself (faucet)
+* issuer will firstly mint tokens and then transfer
+* smart contract will mint tokens for a user
+
+Moreover, there are tools which filter transactions to report user tokens in a dashboard (eg the NEAR Wallet).
+These tools will usually check the first transaction. In case of NEAR Wallet it check for the `ft_transfer`, `ft_transfer_call` function calls. If a user will receive a token through minting, the it won't be reported (see  Minted Tokens via Contract not showing in Wallet [#468](https://github.com/near/near-contract-helper/issues/468) issue). So, we need a standard interface in order to have a tool support.
+
+## Standard Interface
+
+```ts
+// Fungible Token minting.
+// Smart contract can do additional check or validation about who can call this
+// function or under what circumstances.
+// Requirements:
+// * Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes
+//
+// Arguments:
+// * `receiver_id`: the valid NEAR account receiving the fungible tokens.
+// * `amount`: the number of tokens to transfer as a string number. Function MUST panic
+//   if the amount is not a positive 128 bit number.
+// * `memo` (optional): for use cases that may benefit from indexing or
+//    providing information for the minting logic.
+//
+// payable
+function ft_mint(
+    receiver_id: string,
+    amount: string,
+    memo: string|null
+): void {}
+```

--- a/specs/Standards/FungibleToken/Minting.md
+++ b/specs/Standards/FungibleToken/Minting.md
@@ -5,7 +5,7 @@ Version `1.0.0`
 ## Summary
 [summary]: #summary
 
-An interface for a fungible token minting, which is usually a part of a token lifecycle,
+An interface for a fungible token minting, which is usually a part of a token life cycle,
 
 ## Motivation
 

--- a/specs/Standards/FungibleToken/Minting.md
+++ b/specs/Standards/FungibleToken/Minting.md
@@ -17,7 +17,7 @@ In a minting life cycle, token will be firstly minted and then transferred. Foll
 * smart contract will mint tokens for a user
 
 Moreover, there are tools which filter transactions to report user tokens in a dashboard (eg the NEAR Wallet).
-These tools will usually check the first transaction. In case of NEAR Wallet it check for the `ft_transfer`, `ft_transfer_call` function calls. If a user will receive a token through minting, the it won't be reported (see  Minted Tokens via Contract not showing in Wallet [#468](https://github.com/near/near-contract-helper/issues/468) issue). So, we need a standard interface in order to have a tool support.
+These tools will usually check the first transaction. In case of NEAR Wallet it check for the `ft_transfer`, `ft_transfer_call` function calls. If a user will receive a token through minting, then it won't be reported (see Minted Tokens via Contract not showing in Wallet [#468](https://github.com/near/near-contract-helper/issues/468) issue). So, we need a standard interface in order to have a tool support.
 
 ## Standard Interface
 

--- a/specs/Standards/FungibleToken/README.md
+++ b/specs/Standards/FungibleToken/README.md
@@ -2,3 +2,4 @@
 
 - [Fungible Token Core](Core.md)
 - [Fungible Token Metadata](Metadata.md)
+- [Fungible Token Minting](Minting.md)


### PR DESCRIPTION
## Summary

An interface for a fungible token minting, which is usually a part of a token life cycle,

## Motivation

Token minting can be triggered by other smart contracts. Hence we need a standard interface for minting.

In a minting life cycle, token will be firstly minted and then transferred. Following scenarios are possible:
* user can mint tokens for himself (faucet)
* issuer will firstly mint tokens and then transfer
* smart contract will mint tokens for a user

Moreover, there are tools which filter transactions to report user tokens in a dashboard (eg the NEAR Wallet).
These tools will usually check the first transaction. In case of NEAR Wallet it check for the `ft_transfer`, `ft_transfer_call` function calls. If a user will receive a token through minting, the it won't be reported (see  Minted Tokens via Contract not showing in Wallet [#468](https://github.com/near/near-contract-helper/issues/468) issue). So, we need a standard interface in order to have a tool support.

## Outcome

We decided to reject this proposal. Reason:

* Most tokens don't just allow someone to mint them, they are minted as part of a more complex transaction, and this API is not suitable for this case. As a result, this API has very limited usability.
* Scope for token minting tools is very limited.
* User balance tracking should use events, not `ft_mint` calls. Tokens can be minted through various flows.