### PR TITLE
fix: resolve inconsistent types

### DIFF
--- a/specs/Standards/NonFungibleToken/ApprovalManagement.md
+++ b/specs/Standards/NonFungibleToken/ApprovalManagement.md
@@ -334,7 +334,7 @@ The NFT contract must implement the following methods:
 // Returns void, if no `msg` given. Otherwise, returns promise call to
 // `nft_on_approve`, which can resolve with whatever it wants.
 function nft_approve(
-  token_id: TokenId,
+  token_id: string,
   account_id: string,
   msg: string|null,
 ): void|Promise<any> {}
@@ -428,7 +428,7 @@ If a contract that gets approved to transfer NFTs wants to, it can implement `nf
 //    handle the approval. Can indicate both a function to call and the
 //    parameters to pass to that function.
 function nft_on_approve(
-  token_id: TokenId,
+  token_id: string,
   owner_id: string,
   approval_id: number,
   msg: string,

--- a/specs/Standards/NonFungibleToken/Payout.md
+++ b/specs/Standards/NonFungibleToken/Payout.md
@@ -78,7 +78,7 @@ pub trait Payouts{
   fn nft_transfer_payout(
     &mut self,
     receiver_id: AccountId,
-    token_id: String,
+    token_id: U64,
     approval_id: U64,
     balance: U128,
     max_len_payout: u32,


### PR DESCRIPTION
Most NEPs have been written in Typescript interfaces and others Rust.

Since smart contracts in near are primarily written in Rust, it makes sense to use Rust. But definitely having 2 different language interfaces is confusing and has led to this pr.

We should have 1 language interface instead of 2. I hope this is the start of discussions that will lead to improved standards.