### PR TITLE
fix(nft-payouts): Missing memo argument.

### DIFF
--- a/specs/Standards/NonFungibleToken/Payout.md
+++ b/specs/Standards/NonFungibleToken/Payout.md
@@ -87,7 +87,7 @@ pub trait Payouts {
     receiver_id: AccountId,
     token_id: String,
     approval_id: u64,
-    memo: Option<u64>
+    memo: Option<u64>,
     balance: U128,
     max_len_payout: u32,
   ) -> Payout {

--- a/specs/Standards/NonFungibleToken/Payout.md
+++ b/specs/Standards/NonFungibleToken/Payout.md
@@ -1,25 +1,30 @@
 # Standard for a Multiple-Recipient-Payout mechanic on NFT Contracts (NEP-199)
+
 Version `2.0.0`.
 
 This standard assumes the NFT contract has implemented
 [NEP-171](https://github.com/near/NEPs/blob/master/specs/Standards/NonFungibleToken/Core.md) (Core) and [NEP-178](https://github.com/near/NEPs/blob/master/specs/Standards/NonFungibleToken/ApprovalManagement.md) (Approval Management).
 
 ## Summary
+
 An interface allowing non-fungible token contracts to request that financial contracts pay-out multiple receivers, enabling flexible royalty implementations.
 
 ## Motivation
-Currently, NFTs on NEAR support the field `owner_id`, but lack flexibility for ownership and payout mechanics with more complexity, including but not limited to royalties. Financial contracts, such as marketplaces, auction houses, and NFT Loan contracts would benefit from a standard interface on NFT producer contracts for querying whom to pay out, and how much to pay.
+
+Currently, NFTs on NEAR support the field `owner_id`, but lack flexibility for ownership and payout mechanics with more complexity, including but not limited to royalties. Financial contracts, such as marketplaces, auction houses, and NFT loan contracts would benefit from a standard interface on NFT producer contracts for querying whom to pay out, and how much to pay.
 
 Therefore, the core goal of this standard is to define a set of methods for financial contracts to call, without specifying how NFT contracts define the divide of payout mechanics, and a standard `Payout` response structure.
 
 ## Guide-level explanation
 
 This Payout extension standard adds two methods to NFT contracts:
+
 - a view method: `nft_payout`, accepting a `token_id` and some `balance`, returning the `Payout` mapping for the given token.
 - a call method: `nft_transfer_payout`, accepting all the arguments of`nft_transfer`, plus a field for some `Balance` that calculates the `Payout`, calls `nft_transfer`, and returns the `Payout` mapping.
 
 Financial contracts MUST validate several invariants on the returned
 `Payout`:
+
 1. The returned `Payout` MUST be no longer than the given maximum length (`max_len_payout` parameter) if provided. Payouts of excessive length can become prohibitively gas-expensive. Financial contracts can specify the maximum length of payout the contract is willing to respect with the `max_len_payout` field on `nft_transfer_payout`.
 2. The balances MUST add up to less than or equal to the `balance` argument in `nft_transfer_payout`. If the balance adds up to less than the `balance` argument, the financial contract MAY claim the remainder for itself.
 3. The sum of the balances MUST NOT overflow. This is technically identical to 2, but financial contracts should be expected to handle this possibility.
@@ -32,6 +37,7 @@ If the Payout contains any addresses that do not exist, the financial contract M
 Financial contracts MAY take a cut of the NFT sale price as commission, subtracting their cut from the total token sale price, and calling `nft_transfer_payout` with the remainder.
 
 ## Example Flow
+
 ```
  ┌─────────────────────────────────────────────────┐
  │Token Owner approves marketplace for token_id "0"│
@@ -54,6 +60,7 @@ Financial contracts MAY take a cut of the NFT sale price as commission, subtract
 ```
 
 ## Reference-level explanation
+
 ```rust
 /// A mapping of NEAR accounts to the amount each should be paid out, in
 /// the event of a token-sale. The payout mapping MUST be shorter than the
@@ -66,7 +73,7 @@ pub struct Payout {
   pub payout: HashMap<AccountId, U128>,
 }
 
-pub trait Payouts{
+pub trait Payouts {
   /// Given a `token_id` and NEAR-denominated balance, return the `Payout`.
   /// struct for the given token. Panic if the length of the payout exceeds
   /// `max_len_payout.`
@@ -80,12 +87,13 @@ pub trait Payouts{
     receiver_id: AccountId,
     token_id: String,
     approval_id: u64,
+    memo: Option<u64>
     balance: U128,
     max_len_payout: u32,
-  ) -> Payout{
+  ) -> Payout {
     assert_one_yocto();
     let payout = self.nft_payout(token_id, balance);
-    self.nft_transfer(receiver_id, token_id, approval_id);
+    self.nft_transfer(receiver_id, token_id, approval_id, memo);
     payout
   }
 }


### PR DESCRIPTION
As the title says the `memo` argument in the `nft_transfer_payout` was missing.

However, after reviewing the details of this standard I also have several questions.


1.  Why is a the payouts a struct and not a type alias. e.g.
```rust
type Payouts = HashMap<AccountIds, U128>;
```

(update: This is how Paras defines the type).

2. Where did the max length of 10 come from?  Since the consumer is going to iterate over the entries would a vector of tuples decrease this cost?

3. If the contract call would fail with too many payouts anyway, why introduce this implementation detail into the API?

4. As the `nft_transfer_payout` default implementation shows, it is made up of calls to external APIs.  So why does the contract need to implement it?
