### PR TITLE
doc(nft): add example to events with authorized_id

### DIFF
--- a/specs/Standards/NonFungibleToken/Event.md
+++ b/specs/Standards/NonFungibleToken/Event.md
@@ -104,7 +104,7 @@ interface NftMintLog {
 // An event log to capture token burning
 // Arguments
 // * `owner_id`: owner of tokens to burn
-// * `authorized_id`: approved account to burn, if applicable
+// * `authorized_id`: approved account_id to burn, if applicable
 // * `token_ids`: ["1","2"]
 // * `memo`: optional message
 interface NftBurnLog {
@@ -116,7 +116,7 @@ interface NftBurnLog {
 
 // An event log to capture token transfer
 // Arguments
-// * `authorized_id`: approved account to transfer
+// * `authorized_id`: approved account_id to transfer, if applicable
 // * `old_owner_id`: "owner.near"
 // * `new_owner_id`: "receiver.near"
 // * `token_ids`: ["1", "12345abc"]
@@ -179,6 +179,19 @@ EVENT_JSON:{
   "event": "nft_transfer",
   "data": [
     {"old_owner_id": "user1.near", "new_owner_id": "user2.near", "token_ids": ["meme"], "memo": "have fun!"}
+  ]
+}
+```
+
+Authorized id:
+
+```js
+EVENT_JSON:{
+  "standard": "nep171",
+  "version": "1.0.0",
+  "event": "nft_burn",
+  "data": [
+    {"owner_id": "owner.near", "token_ids": ["goodbye", "aurevoir"], "authorized_id": "thirdparty.near"}
   ]
 }
 ```


### PR DESCRIPTION
We've already collected some information about NFTs in Indexer DB.

Some of the entries do not follow our standard fully: `authorized_id` is filled by ids from internal contract implementation (examples: 1, 2, 7).
I feel it's our fault; we do not communicate this part properly. I've added one more example to the doc.

Another part of the issue is to share it with the contract creators.
For now, we have only one contract that used `authorized_id` field
https://explorer.near.org/accounts/misfits.tenk.near
It's not hard to google them
https://paras.id/collection/misfits.tenk.near

Does anyone know how to contact them?