### PR TITLE
feat(NFT): add memo and authorized_id to `nft_resolve_transfer`

### DIFF
--- a/specs/Standards/NonFungibleToken/Core.md
+++ b/specs/Standards/NonFungibleToken/Core.md
@@ -166,6 +166,7 @@ function nft_resolve_transfer(
   owner_id: string,
   receiver_id: string,
   token_id: string,
+  authorized_id: null|string,
   approved_account_ids: null|Record<string, number>,
   memo: null|string
 ): boolean {}

--- a/specs/Standards/NonFungibleToken/Core.md
+++ b/specs/Standards/NonFungibleToken/Core.md
@@ -159,6 +159,7 @@ The following behavior is required, but contract authors may name this function 
 // * `approved_account_ids `: if using Approval Management, contract MUST provide
 //   record of original approved accounts in this argument, and restore these
 //   approved accounts and their approval IDs in case of revert.
+// * `memo` (optional): to be included in event log if transfer is sucessful.
 //
 // Returns true if token was successfully transferred to `receiver_id`.
 function nft_resolve_transfer(
@@ -166,6 +167,7 @@ function nft_resolve_transfer(
   receiver_id: string,
   token_id: string,
   approved_account_ids: null|Record<string, number>,
+  memo: null|string
 ): boolean {}
 ```
 


### PR DESCRIPTION
In the case where a `nft_transfer_call` is successful the event from the transaction should be emitted by `nft_resolve_transfer`.  If the event is emitted by the initial call to `nft_transfer_call` and the promise of `nft_on_transfer` fails, then an additional log must be emitted when `nft_resolve_transfer` rolls the transaction back.

Thus it should be the case that `nft_relove_transfer` emits the log only if the transaction was successful.  However, it is missing access to the `memo` parameter  and the `authorized_id` that both need to be emitted which this PR adds.
