### PR TITLE
doc(standards): add link to events format nep

### DIFF
--- a/specs/Standards/README.md
+++ b/specs/Standards/README.md
@@ -12,3 +12,4 @@
     - [Royalty Payout](NonFungibleToken/Payout.md)
     - [Events](NonFungibleToken/Event.md)
 - [Storage Management](StorageManagement.md)
+- [Events Format](EventsFormat.md)


### PR DESCRIPTION
The link from the start page is missing
https://nomicon.io/Standards/README.html