### PR TITLE
Changed navbar for nft standard to be shorter and more informative

### DIFF
--- a/specs/Standards/NonFungibleToken/ApprovalManagement.md
+++ b/specs/Standards/NonFungibleToken/ApprovalManagement.md
@@ -1,4 +1,4 @@
-# Non-Fungible Token Approval Management
+# Approval Management
 
 ## [NEP-178](https://github.com/near/NEPs/discussions/178)
 

--- a/specs/Standards/NonFungibleToken/Core.md
+++ b/specs/Standards/NonFungibleToken/Core.md
@@ -1,4 +1,4 @@
-# Non-Fungible Token
+# Core Functionality
 
 ## [NEP-171](https://github.com/near/NEPs/discussions/171)
 

--- a/specs/Standards/NonFungibleToken/Enumeration.md
+++ b/specs/Standards/NonFungibleToken/Enumeration.md
@@ -1,4 +1,4 @@
-# Non-Fungible Token Enumeration
+# Enumeration
 
 ## [NEP-181](https://github.com/near/NEPs/discussions/181)
 

--- a/specs/Standards/NonFungibleToken/Event.md
+++ b/specs/Standards/NonFungibleToken/Event.md
@@ -1,4 +1,4 @@
-# Non-Fungible Token Event
+# Events
 
 Version `1.0.0`
 

--- a/specs/Standards/NonFungibleToken/Metadata.md
+++ b/specs/Standards/NonFungibleToken/Metadata.md
@@ -1,4 +1,4 @@
-# Non-Fungible Token Metadata
+# Metadata
 
 ## [NEP-177](https://github.com/near/NEPs/discussions/177)
 

--- a/specs/Standards/NonFungibleToken/Payout.md
+++ b/specs/Standards/NonFungibleToken/Payout.md
@@ -1,4 +1,4 @@
-# Standard for a Multiple-Recipient-Payout mechanic on NFT Contracts
+# Royalties and Payouts
 
 ## (NEP-199)
 


### PR DESCRIPTION
The navbar is pretty busy right now and hard to look at: 
<img width="247" alt="image" src="https://user-images.githubusercontent.com/57506486/155390571-e0800c6b-1d1c-478a-b03a-7e7f13c83c69.png">

I've changed it to be shorter:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/57506486/155390624-b929e633-3611-4af2-8b1c-5721f4dee80a.png">
