### PR TITLE
feat: add `standards` key to `ContractSourceMetadata`

### DIFF
--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -102,8 +102,8 @@ pub struct Contract {
 }
 
 // NEP structure
-pub struct NEP {
-    pub NEP: u16,
+pub struct Standard {
+    pub standard: String,
     pub version: String
 }
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -1,12 +1,14 @@
 ---
 NEP: 330
 Title: Source Metadata
-Author: Ben Kurrek <ben.kurrek@near.org>
+Author: Ben Kurrek <ben.kurrek@near.org>, Osman Abdelnasir <osman@near.org>
 DiscussionsTo: https://github.com/near/NEPs/discussions/329
-Status: Review
+Status: Approved
 Type: Standards Track
 Category: Contract
+Version: 1.1.0
 Created: 27-Feb-2022
+Updated: 13-Jan-2023
 ---
 
 ## Summary
@@ -29,20 +31,21 @@ There is a lot of information that can be held about a contract. Ultimately, we 
 
 Successful implementations of this standard will introduce a new  (`ContractSourceMetadata`) struct that will hold all the necessary information to be queried for. This struct will be kept on the contract level.
 
-The metadata will include two optional fields:
+The metadata will include three optional fields:
 - `version`: a string that references the specific commit hash or version of the code that is currently deployed on-chain. This can be included regardless of whether or not the contract is open-sourced and can also be used for organizational purposes.
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
+- `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 
 ```ts
-type Standard {
-    standard: string, // standard name e.g. "nep141"
-    version: string // semantic version number of the Standard e.g. "1.0.0"
-}
-
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
-  standards: Standard[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep141", version: "1.0.0"},{standard: "nep148", version: "1.0.0"}].
+  link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
+  standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+}
+
+type Standard {
+    standard: string, // standard name e.g. "nep141"
+    version: string, // semantic version number of the Standard e.g. "1.0.0"
 }
 ```
 
@@ -62,12 +65,16 @@ type ContractSourceMetadata = {
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
+        standard: "nep330", 
+        version: "1.1.0"
+    },
+    {
         standard: "nep171", 
-        version: "1.0.2"
+        version: "1.0.0"
     },
     {
         standard: "nep177", 
-        version: "2.0.1"
+        version: "2.0.0"
     }
   ]
 }
@@ -81,12 +88,16 @@ If someone were to call the view function `contract_metadata`, the contract woul
     link: "https://github.com/near-examples/nft-tutorial",
     standards: [
         {
+            standard: "nep330", 
+            version: "1.1.0"
+        },
+        {
             standard: "nep171", 
-            version: "1.0.2"
+            version: "1.0.0"
         },
         {
             standard: "nep177", 
-            version: "2.0.1"
+            version: "2.0.0"
         }
     ]
 }
@@ -131,6 +142,31 @@ impl ContractSourceMetadataTrait for Contract {
 ## Future possibilities
 
 - By having a standard outlining metadata for an arbitrary contract, any information that pertains on a contract level can be added based on the requests of the developer community.
+
+## Decision Context
+
+### 1.0.0 - Initial Version
+
+The initial version of NEP-330 was approved by @jlogelin on Mar 29, 2022.
+
+### 1.1.0 - Contract Metadata Extension
+
+The extension NEP-351 that added Contract Metadata to this NEP-330 was approved by Contract Standards Working Group members on January 17, 2023 ([meeting recording](https://youtu.be/pBLN9UyE6AA)).
+
+#### Benefits
+
+- Unlocks NEP extensions that otherwise would be hard to integrate into the tooling as it would be guess-based (e.g. see "interface detection" concerns in the Non-transferrable NFT NEP)
+- Standardization enables composability as it makes it easier to interact with contracts when you can programmatically check compatibility
+- This NEP extension introduces an optional field, so there is no breaking change to the original NEP
+
+#### Concerns
+
+| # | Concern | Resolution | Status |
+| - | - | - | - |   
+| 1 | Integer field as a standard reference is limiting as third-party projects may want to introduce their own standards without pushing it through the NEP process | Author accepted the proposed string-value standard reference (e.g. “nep123” instead of just 123, and allow “xyz001” as previously it was not possible to express it) | Resolved |
+| 2 | NEP-330 and NEP-351 should be included in the list of the supported NEPs | There seems to be a general agreement that it is a good default, so NEP was updated | Resolved |
+| 3 | JSON Event could be beneficial, so tooling can react to the changes in the supported standards | It is outside the scope of this NEP. Also, list of supported standards only changes with contract re-deployment, so tooling can track DEPLOY_CODE events and check the list of supported standards when new code is deployed | Won’t fix |
+
 
 ## Copyright
 [copyright]: #copyright

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -34,15 +34,15 @@ The metadata will include two optional fields:
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 
 ```ts
-type NEP {
-    NEP: number, // NEP number e.g. 0141 for NEP-0141
-    version: string // semantic version number of the NEP e.g. "1.0.0"
+type Standard {
+    standard: string, // standard name e.g. "nep141"
+    version: string // semantic version number of the Standard e.g. "1.0.0"
 }
 
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.,
-  standards: NEP[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{NEP: 0141, version: "1.0.0"},{NEP: 0148, version: "1.0.0"}].
+  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
+  standards: Standard[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep141", version: "1.0.0"},{standard: "nep148", version: "1.0.0"}].
 }
 ```
 
@@ -62,11 +62,11 @@ type ContractSourceMetadata = {
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
-        NEP: 0171, 
+        standard: "nep171", 
         version: "1.0.2"
     },
     {
-        NEP: 0177, 
+        standard: "nep177", 
         version: "2.0.1"
     }
   ]
@@ -81,11 +81,11 @@ If someone were to call the view function `contract_metadata`, the contract woul
     link: "https://github.com/near-examples/nft-tutorial",
     standards: [
         {
-            NEP: 0171, 
+            standard: "nep171", 
             version: "1.0.2"
         },
         {
-            NEP: 0177, 
+            standard: "nep177", 
             version: "2.0.1"
         }
     ]
@@ -101,7 +101,7 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
-// NEP structure
+// Standard structure
 pub struct Standard {
     pub standard: String,
     pub version: String
@@ -111,7 +111,7 @@ pub struct Standard {
 pub struct ContractSourceMetadata {
     pub version: String,
     pub link: String,
-    pub standards: [NEP; 2]
+    pub standards: Vec<Standard>
 }
 
 /// Minimum Viable Interface

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -17,7 +17,7 @@ The contract source metadata is a standard interface that allows auditing and vi
 
 There is no trivial way of finding the source code or author of a deployed smart contract. Having a standard that outlines how to view the source code of an arbitrary smart contract creates an environment of openness and collaboration.
 
-Additionally, we would like for wallets and Dapps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
+Additionally, we would like for wallets and dApps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
 
 The initial discussion can be found [here](https://github.com/near/NEPs/discussions/329).
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -27,7 +27,7 @@ There is a lot of information that can be held about a contract. Ultimately, we 
 
 ## Specification
 
-Successful implementations of this standard will introduce a new  (`ContractMetadata`) struct that will hold all the necessary information to be queried for. This struct will be kept on the contract level.
+Successful implementations of this standard will introduce a new  (`ContractSourceMetadata`) struct that will hold all the necessary information to be queried for. This struct will be kept on the contract level.
 
 The metadata will include two optional fields:
 - `version`: a string that references the specific commit hash or version of the code that is currently deployed on-chain. This can be included regardless of whether or not the contract is open-sourced and can also be used for organizational purposes.
@@ -116,7 +116,7 @@ pub struct ContractSourceMetadata {
 
 /// Minimum Viable Interface
 pub trait ContractSourceMetadataTrait {
-    fn contract_source_metadata(&self) -> ContractMetadata;
+    fn contract_source_metadata(&self) -> ContractSourceMetadata;
 }
 
 /// Implementation of the view function

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -17,6 +17,8 @@ The contract source metadata is a standard interface that allows auditing and vi
 
 There is no trivial way of finding the source code or author of a deployed smart contract. Having a standard that outlines how to view the source code of an arbitrary smart contract creates an environment of openness and collaboration.
 
+Additionally, we would like for wallets and Dapps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
+
 The initial discussion can be found [here](https://github.com/near/NEPs/discussions/329).
 
 ## Rationale and alternatives
@@ -32,9 +34,15 @@ The metadata will include two optional fields:
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 
 ```ts
+type NEP {
+    NEP: number, // NEP number e.g. 0141 for NEP-0141
+    version: string // semantic version number of the NEP e.g. "1.0.0"
+}
+
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
+  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.,
+  standards: NEP[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{NEP: 0141, version: "1.0.0"},{NEP: 0148, version: "1.0.0"}].
 }
 ```
 
@@ -51,7 +59,17 @@ As an example, say there was an NFT contract deployed on-chain which was current
 ```ts
 type ContractSourceMetadata = {
   version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-  link: "https://github.com/near-examples/nft-tutorial"
+  link: "https://github.com/near-examples/nft-tutorial",
+  standards: [
+    {
+        NEP: 0171, 
+        version: "1.0.2"
+    },
+    {
+        NEP: 0177, 
+        version: "2.0.1"
+    }
+  ]
 }
 ```
 
@@ -60,7 +78,17 @@ If someone were to call the view function `contract_metadata`, the contract woul
 ```bash
 {
     version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-    link: "https://github.com/near-examples/nft-tutorial"
+    link: "https://github.com/near-examples/nft-tutorial",
+    standards: [
+        {
+            NEP: 0171, 
+            version: "1.0.2"
+        },
+        {
+            NEP: 0177, 
+            version: "2.0.1"
+        }
+    ]
 }
 ```
 
@@ -73,10 +101,17 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
+// NEP structure
+pub struct NEP {
+    pub NEP: u16,
+    pub version: String
+}
+
 /// Contract metadata structure
 pub struct ContractSourceMetadata {
     pub version: String,
     pub link: String,
+    pub standards: [NEP; 2]
 }
 
 /// Minimum Viable Interface

--- a/specs/Standards/SourceMetadata.md
+++ b/specs/Standards/SourceMetadata.md
@@ -2,10 +2,6 @@
 
 ## [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
 
-:::caution
-This is part of proposed spec [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) and subject to change.
-:::
-
 Version `1.1.0`
 
 ## Summary
@@ -16,7 +12,7 @@ The contract source metadata is a standard interface that allows auditing and vi
 
 There is no trivial way of finding the source code or author of a deployed smart contract. Having a standard that outlines how to view the source code of an arbitrary smart contract creates an environment of openness and collaboration.
 
-Additionally, we would like for wallets and Dapps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
+Additionally, we would like for wallets and dApps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
 
 The initial discussion can be found [here](https://github.com/near/NEPs/discussions/329).
 
@@ -31,17 +27,18 @@ Successful implementations of this standard will introduce a new  (`ContractSour
 The metadata will include two optional fields:
 - `version`: a string that references the specific commit hash or version of the code that is currently deployed on-chain. This can be included regardless of whether or not the contract is open-sourced and can also be used for organizational purposes.
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
+- `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 
 ```ts
-type Standard {
-    standard: string, // standard name e.g. "nep141"
-    version: string // semantic version number of the Standard e.g. "1.0.0"
-}
-
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-  link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
-  standards: Standard[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep141", version: "1.0.0"},{standard: "nep148", version: "1.0.0"}].
+  link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
+  standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+}
+
+type Standard {
+    standard: string, // standard name e.g. "nep141"
+    version: string, // semantic version number of the Standard e.g. "1.0.0"
 }
 ```
 
@@ -61,12 +58,16 @@ type ContractSourceMetadata = {
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
+        standard: "nep330", 
+        version: "1.1.0"
+    },
+    {
         standard: "nep171", 
-        version: "1.0.2"
+        version: "1.0.0"
     },
     {
         standard: "nep177", 
-        version: "2.0.1"
+        version: "2.0.0"
     }
   ]
 }
@@ -80,12 +81,16 @@ If someone were to call the view function `contract_metadata`, the contract woul
     link: "https://github.com/near-examples/nft-tutorial",
     standards: [
         {
+            standard: "nep330", 
+            version: "1.1.0"
+        },
+        {
             standard: "nep171", 
-            version: "1.0.2"
+            version: "1.0.0"
         },
         {
             standard: "nep177", 
-            version: "2.0.1"
+            version: "2.0.0"
         }
     ]
 }

--- a/specs/Standards/SourceMetadata.md
+++ b/specs/Standards/SourceMetadata.md
@@ -33,15 +33,15 @@ The metadata will include two optional fields:
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 
 ```ts
-type NEP {
-    NEP: number, // NEP number e.g. 0141 for NEP-0141
-    version: string // semantic version number of the NEP e.g. "1.0.0"
+type Standard {
+    standard: string, // standard name e.g. "nep141"
+    version: string // semantic version number of the Standard e.g. "1.0.0"
 }
 
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
   link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
-  standards: NEP[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{NEP: 0141, version: "1.0.0"},{NEP: 0148, version: "1.0.0"}].
+  standards: Standard[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep141", version: "1.0.0"},{standard: "nep148", version: "1.0.0"}].
 }
 ```
 
@@ -61,11 +61,11 @@ type ContractSourceMetadata = {
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
-        NEP: 0171, 
+        standard: "nep171", 
         version: "1.0.2"
     },
     {
-        NEP: 0177, 
+        standard: "nep177", 
         version: "2.0.1"
     }
   ]
@@ -80,11 +80,11 @@ If someone were to call the view function `contract_metadata`, the contract woul
     link: "https://github.com/near-examples/nft-tutorial",
     standards: [
         {
-            NEP: 0171, 
+            standard: "nep171", 
             version: "1.0.2"
         },
         {
-            NEP: 0177, 
+            standard: "nep177", 
             version: "2.0.1"
         }
     ]
@@ -100,17 +100,17 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
-// NEP structure
-pub struct NEP {
-    pub NEP: u16,
-    pub version: String
+// Standard structure
+type Standard {
+    standard: string, // standard name e.g. "nep141"
+    version: string // semantic version number of the Standard e.g. "1.0.0"
 }
 
 /// Contract metadata structure
 pub struct ContractSourceMetadata {
     pub version: String,
     pub link: String,
-    pub standards: [NEP; 2]
+    pub standards: Vec<Standard>
 }
 
 /// Minimum Viable Interface

--- a/specs/Standards/SourceMetadata.md
+++ b/specs/Standards/SourceMetadata.md
@@ -6,7 +6,7 @@
 This is part of proposed spec [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) and subject to change.
 :::
 
-Version `1.0.0`
+Version `1.1.0`
 
 ## Summary
 
@@ -15,6 +15,8 @@ The contract source metadata is a standard interface that allows auditing and vi
 ## Motivation
 
 There is no trivial way of finding the source code or author of a deployed smart contract. Having a standard that outlines how to view the source code of an arbitrary smart contract creates an environment of openness and collaboration.
+
+Additionally, we would like for wallets and Dapps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
 
 The initial discussion can be found [here](https://github.com/near/NEPs/discussions/329).
 
@@ -31,9 +33,15 @@ The metadata will include two optional fields:
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 
 ```ts
+type NEP {
+    NEP: number, // NEP number e.g. 0141 for NEP-0141
+    version: string // semantic version number of the NEP e.g. "1.0.0"
+}
+
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
   link: string|null, //optional,  link to open source code such as a Github repository or a CID to somewhere on IPFS.
+  standards: NEP[]|null //optional, standards and extensions implemented in the currently deployed wasm e.g. [{NEP: 0141, version: "1.0.0"},{NEP: 0148, version: "1.0.0"}].
 }
 ```
 
@@ -50,7 +58,17 @@ As an example, say there was an NFT contract deployed on-chain which was current
 ```ts
 type ContractSourceMetadata = {
   version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-  link: "https://github.com/near-examples/nft-tutorial"
+  link: "https://github.com/near-examples/nft-tutorial",
+  standards: [
+    {
+        NEP: 0171, 
+        version: "1.0.2"
+    },
+    {
+        NEP: 0177, 
+        version: "2.0.1"
+    }
+  ]
 }
 ```
 
@@ -59,7 +77,17 @@ If someone were to call the view function `contract_metadata`, the contract woul
 ```bash
 {
     version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-    link: "https://github.com/near-examples/nft-tutorial"
+    link: "https://github.com/near-examples/nft-tutorial",
+    standards: [
+        {
+            NEP: 0171, 
+            version: "1.0.2"
+        },
+        {
+            NEP: 0177, 
+            version: "2.0.1"
+        }
+    ]
 }
 ```
 
@@ -72,10 +100,17 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
+// NEP structure
+pub struct NEP {
+    pub NEP: u16,
+    pub version: String
+}
+
 /// Contract metadata structure
 pub struct ContractSourceMetadata {
     pub version: String,
     pub link: String,
+    pub standards: [NEP; 2]
 }
 
 /// Minimum Viable Interface


### PR DESCRIPTION
This PR proposes the addition of an optional `standards` value to the `ContractSourceMetadata` type recently introduced in [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) (#330). 

This will allow wallets and Dapps to be able to more easily identify what type of contract they are dealing with and what functionality to expect and render without having to test for those methods and events existing. 

One example use case of this is to introduce an extension that implements `buy` / `sell` for the [USN](https://github.com/binary-star-near/usn) contract and add it as `ContractSourceMetadata` so we can provide the functionality conditionally for fungible tokens in near/near-wallet#2568.

Additionally, this PR fixes missed updates of `ContractMetadata` to `ContractSourceMetadata` [here](https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L28) and [here](https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L84).