### PR TITLE
Respect system preference for theme in website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,6 +64,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        respectPrefersColorScheme: true
+      },
       navbar: {
         title: 'Nomicon',
         logo: {


### PR DESCRIPTION
Relevant documentation for this version of docusaurus: https://6220d0362c028b000827f851--docusaurus-2.netlify.app/docs/2.0.0-beta.15/api/themes/configuration#respectPrefersColorScheme

Sorry for not going through any specific process for this PR. It's not a Spec change so I've just committed via the UI and opened the PR.