### PR TITLE
Fixed Error in Access Key Docs

### DIFF
--- a/specs/DataStructures/AccessKey.md
+++ b/specs/DataStructures/AccessKey.md
@@ -15,7 +15,7 @@ pub struct AccessKey {
 }
 ```
 
-There are 2 types of `AccessKeyPermission` in Near currently: `FullAccess` and `FunctionCall`. `FullAccess` grants permission to request any action on an account like [DeployContract](Transaction.md#DeployContract), [Transfer](Transaction.md#Transfer) tokens to other account, calling functions on smart contracts [FunctionCall](Transaction.md#FunctionCall), [Stake](Transaction.md#Stake) and even delete accounts [DeleteAccountAction](Transaction.md#DeleteAccountAction). `FullAccess` also allows managing access keys. `AccessKeyPermission::FunctionCall` is limited to only having permission to call non-payable methods on contracts.
+There are 2 types of `AccessKeyPermission` in NEAR currently: `FullAccess` and `FunctionCall`. `FullAccess` grants permissions to issue any action on the account. This includes [DeployContract](../RuntimeSpec/Actions.md#DeployContractAction), [Transfer](../RuntimeSpec/Actions.md#TransferAction) tokens, call functions [FunctionCall](../RuntimeSpec/Actions.md#FunctionCallAction), [Stake](../RuntimeSpec/Actions.md#StakeAction) and even permission to delete the account [DeleteAccountAction](../RuntimeSpec/Actions.md#DeleteAccountAction). `FunctionCall` on the other hand, **only** grants permission to call any or a specific set of methods on one given contract. It has an allowance of $NEAR that can be spent on **GAS and transaction fees only**. Function call access keys **cannot** be used to transfer $NEAR.
 
 ```rust
 pub enum AccessKeyPermission {
@@ -26,7 +26,7 @@ pub enum AccessKeyPermission {
 
 ## AccessKeyPermission::FunctionCall
 
-Grants limited permission to make [FunctionCall](Transaction.md#FunctionCall) to a specified `receiver_id` and methods of a particular contract with a limit of allowed balance to spend.
+Grants limited permission to make [FunctionCall](../RuntimeSpec/Actions.md#FunctionCall) to a specified `receiver_id` and methods of a particular contract with a limit of allowed balance to spend.
 
 ```rust
 pub struct FunctionCallPermission {


### PR DESCRIPTION
Fixed the access key docs which previously mixed up function call and full access key permissions.