### PR TITLE
Update urls on NEPs

### DIFF
--- a/neps/nep-0001.md
+++ b/neps/nep-0001.md
@@ -16,7 +16,7 @@ a new feature for the Near protocol, Smart Contract standards, or it's environme
 The NEP should provide a concise technical specification of the feature and a
 rationale for the feature.
 
-NEPs are intented to be the primary mechanism for proposing new features, interfacing
+NEPs are intended to be the primary mechanism for proposing new features, interfacing
 with the community on an issue and documenting design decisions that have
 been integrated into Near's runtime or Smart Contract ecosystem.
 
@@ -274,7 +274,7 @@ header preamble. The headers must appear in the following order.
 ```
   NEP: <NEP number>
   Title: <NEP title>
-  Author: <list of authors' real names and optionally, email addrs>
+  Author: <list of authors' real names and optionally, email address>
   DiscussionsTo: <URL of current canonical discussion thread or threads>
   Status: <Draft | Review | Last Call | Final | Living | Deprecated>
   Type: <Standards Track | Informational | Process>

--- a/neps/nep-0141.md
+++ b/neps/nep-0141.md
@@ -13,8 +13,8 @@ Requires: 297
 
 ## Summary
 
-A standard interface for fungible tokens that allows for a normal transfer as well as a transfer and method call in a single transaction. The [storage standard](../specs/Standards/StorageManagement.md) addresses the needs (and security) of storage staking.
-The [fungible token metadata standard](../specs/Standards/Tokens/FungibleToken/Metadata.md) provides the fields needed for ergonomics across dApps and marketplaces.
+A standard interface for fungible tokens that allows for a normal transfer as well as a transfer and method call in a single transaction. The [storage standard][Storage Management] addresses the needs (and security) of storage staking.
+The [fungible token metadata standard][FT Metadata] provides the fields needed for ergonomics across dApps and marketplaces.
 
 ## Motivation
 
@@ -59,9 +59,9 @@ There are a few concepts in the scenarios above:
 - **Transfer and call**: an action that moves some amount from one account to a contract account where the receiver calls a method.
 - **Storage amount**: the amount of storage used for an account to be "registered" in the fungible token. This amount is denominated in Ⓝ, not bytes, and represents the [storage staked](https://docs.near.org/docs/concepts/storage-staking).
 
-Note that precision (the number of decimal places supported by a given token) is not part of this core standard, since it's not required to perform actions. The minimum value is always 1 token. See the [Fungible Token Metadata Standard](../specs/Standards/Tokens/FungibleToken/Metadata.md) to learn how to support precision/decimals in a standardized way.
+Note that precision (the number of decimal places supported by a given token) is not part of this core standard, since it's not required to perform actions. The minimum value is always 1 token. See the [Fungible Token Metadata Standard][FT Metadata] to learn how to support precision/decimals in a standardized way.
 
-Given that multiple users will use a Fungible Token contract, and their activity will result in an increased [storage staking](https://docs.near.org/docs/concepts/storage-staking) burden for the contract's account, this standard is designed to interoperate nicely with [the Account Storage standard](../specs/Standards/StorageManagement.md) for storage deposits and refunds.
+Given that multiple users will use a Fungible Token contract, and their activity will result in an increased [storage staking](https://docs.near.org/docs/concepts/storage-staking) burden for the contract's account, this standard is designed to interoperate nicely with [the Account Storage standard][Storage Management] for storage deposits and refunds.
 
 #### Example scenarios
 
@@ -186,7 +186,7 @@ Altogether then, Alice may take two steps, though the first may be a background 
 - All amounts, balances and allowance are limited by `U128` (max value `2**128 - 1`).
 - Token standard uses JSON for serialization of arguments and results.
 - Amounts in arguments and results have are serialized as Base-10 strings, e.g. `"100"`. This is done to avoid JSON limitation of max integer value of `2**53`.
-- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard](../specs/Standards/StorageManagement.md).
+- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard][Storage Management].
 - To prevent the deployed contract from being modified or deleted, it should not have any access keys on its account.
 
 #### Interface:
@@ -331,7 +331,7 @@ Standard interfaces for FT contract actions that extend [NEP-297](nep-0297.md)
 NEAR and third-party applications need to track `mint`, `transfer`, `burn` events for all FT-driven apps consistently.
 This extension addresses that.
 
-Keep in mind that applications, including NEAR Wallet, could require implementing additional methods, such as [`ft_metadata`](../specs/Standards/Tokens/FungibleToken/Metadata.md), to display the FTs correctly.
+Keep in mind that applications, including NEAR Wallet, could require implementing additional methods, such as [`ft_metadata`][FT Metadata], to display the FTs correctly.
 
 ### Event Interface
 
@@ -435,7 +435,7 @@ EVENT_JSON:{
 
 Note that the example events covered above cover two different kinds of events:
 1. Events that are not specified in the FT Standard (`ft_mint`, `ft_burn`)
-2. An event that is covered in the [FT Core Standard](../specs/Standards/Tokens/FungibleToken/Core.md). (`ft_transfer`)
+2. An event that is covered in the [FT Core Standard][FT Core]. (`ft_transfer`)
 
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.
 
@@ -468,3 +468,7 @@ See also the discussions:
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[Storage Management]: ../specs/Standards/StorageManagement.md
+[FT Metadata]: ../specs/Standards/Tokens/FungibleToken/Metadata.md
+[FT Core]: ../specs/Standards/Tokens/FungibleToken/Core.md

--- a/neps/nep-0141.md
+++ b/neps/nep-0141.md
@@ -13,8 +13,8 @@ Requires: 297
 
 ## Summary
 
-A standard interface for fungible tokens that allows for a normal transfer as well as a transfer and method call in a single transaction. The [storage standard](../StorageManagement.md) addresses the needs (and security) of storage staking.
-The [fungible token metadata standard](Metadata.md) provides the fields needed for ergonomics across dApps and marketplaces.
+A standard interface for fungible tokens that allows for a normal transfer as well as a transfer and method call in a single transaction. The [storage standard](../specs/Standards/StorageManagement.md) addresses the needs (and security) of storage staking.
+The [fungible token metadata standard](../specs/Standards/Tokens/FungibleToken/Metadata.md) provides the fields needed for ergonomics across dApps and marketplaces.
 
 ## Motivation
 
@@ -37,7 +37,7 @@ Prior art:
 
 Learn about NEP-141:
 
-- [Figment Learning Pathway](https://learn.figment.io/network-documentation/near/tutorials/1-project_overview/2-fungible-token)
+- [Figment Learning Pathway](https://learn.figment.io/tutorials/stake-fungible-token)
 
 ## Specification
 
@@ -59,9 +59,9 @@ There are a few concepts in the scenarios above:
 - **Transfer and call**: an action that moves some amount from one account to a contract account where the receiver calls a method.
 - **Storage amount**: the amount of storage used for an account to be "registered" in the fungible token. This amount is denominated in Ⓝ, not bytes, and represents the [storage staked](https://docs.near.org/docs/concepts/storage-staking).
 
-Note that precision (the number of decimal places supported by a given token) is not part of this core standard, since it's not required to perform actions. The minimum value is always 1 token. See the [Fungible Token Metadata Standard](Metadata.md) to learn how to support precision/decimals in a standardized way.
+Note that precision (the number of decimal places supported by a given token) is not part of this core standard, since it's not required to perform actions. The minimum value is always 1 token. See the [Fungible Token Metadata Standard](../specs/Standards/Tokens/FungibleToken/Metadata.md) to learn how to support precision/decimals in a standardized way.
 
-Given that multiple users will use a Fungible Token contract, and their activity will result in an increased [storage staking](https://docs.near.org/docs/concepts/storage-staking) burden for the contract's account, this standard is designed to interoperate nicely with [the Account Storage standard](../StorageManagement.md) for storage deposits and refunds.
+Given that multiple users will use a Fungible Token contract, and their activity will result in an increased [storage staking](https://docs.near.org/docs/concepts/storage-staking) burden for the contract's account, this standard is designed to interoperate nicely with [the Account Storage standard](../specs/Standards/StorageManagement.md) for storage deposits and refunds.
 
 #### Example scenarios
 
@@ -186,7 +186,7 @@ Altogether then, Alice may take two steps, though the first may be a background 
 - All amounts, balances and allowance are limited by `U128` (max value `2**128 - 1`).
 - Token standard uses JSON for serialization of arguments and results.
 - Amounts in arguments and results have are serialized as Base-10 strings, e.g. `"100"`. This is done to avoid JSON limitation of max integer value of `2**53`.
-- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard](../StorageManagement.md).
+- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard](../specs/Standards/StorageManagement.md).
 - To prevent the deployed contract from being modified or deleted, it should not have any access keys on its account.
 
 #### Interface:
@@ -331,7 +331,7 @@ Standard interfaces for FT contract actions that extend [NEP-297](nep-0297.md)
 NEAR and third-party applications need to track `mint`, `transfer`, `burn` events for all FT-driven apps consistently.
 This extension addresses that.
 
-Keep in mind that applications, including NEAR Wallet, could require implementing additional methods, such as [`ft_metadata`](Metadata.md), to display the FTs correctly.
+Keep in mind that applications, including NEAR Wallet, could require implementing additional methods, such as [`ft_metadata`](../specs/Standards/Tokens/FungibleToken/Metadata.md), to display the FTs correctly.
 
 ### Event Interface
 
@@ -435,7 +435,7 @@ EVENT_JSON:{
 
 Note that the example events covered above cover two different kinds of events:
 1. Events that are not specified in the FT Standard (`ft_mint`, `ft_burn`)
-2. An event that is covered in the [FT Core Standard](Core.md). (`ft_transfer`)
+2. An event that is covered in the [FT Core Standard](../specs/Standards/Tokens/FungibleToken/Core.md). (`ft_transfer`)
 
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.
 

--- a/neps/nep-0145.md
+++ b/neps/nep-0145.md
@@ -49,7 +49,7 @@ To show the flexibility and power of this standard, let's walk through two examp
 
 ### Example 1: Fungible Token Contract
 
-Imagine a [fungible token](FungibleToken/Core.md) contract deployed at `ft`. Let's say this contract saves all user balances to a Map data structure internally, and adding a key for a new user requires 0.00235Ⓝ. This contract therefore uses the Storage Management standard to pass this cost onto users, so that a new user must effectively pay a registration fee to interact with this contract of 0.00235Ⓝ, or 2350000000000000000000 yoctoⓃ ([yocto](https://www.metricconversion.us/prefixes.htm) = 10<sup>-24</sup>).
+Imagine a [fungible token][FT Core] contract deployed at `ft`. Let's say this contract saves all user balances to a Map data structure internally, and adding a key for a new user requires 0.00235Ⓝ. This contract therefore uses the Storage Management standard to pass this cost onto users, so that a new user must effectively pay a registration fee to interact with this contract of 0.00235Ⓝ, or 2350000000000000000000 yoctoⓃ ([yocto](https://www.metricconversion.us/prefixes.htm) = 10<sup>-24</sup>).
 
 For this contract, `storage_balance_bounds` will be:
 
@@ -183,7 +183,7 @@ Bob wants to close his account, but has a non-zero balance of `ft` tokens.
 
    It fails with a message like "Cannot gracefully close account with positive remaining balance; bob has balance N"
 
-2. Bob transfers his tokens to a friend using `ft_transfer` from the [Fungible Token Core](FungibleToken/Core.md) standard.
+2. Bob transfers his tokens to a friend using `ft_transfer` from the [Fungible Token Core][FT Core] standard.
 
 3. Bob tries the call from Step 1 again. It works.
 
@@ -452,3 +452,5 @@ The `near-contract-standards` cargo package of the [Near Rust SDK](https://githu
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[FT Core]: ../specs/Standards/Tokens/FungibleToken/Core.md

--- a/neps/nep-0148.md
+++ b/neps/nep-0148.md
@@ -88,7 +88,7 @@ type FungibleTokenMetadata = {
 
 **An implementing contract MUST include the following fields on-chain**
 
-- `spec`: a string. Should be `ft-1.0.0` to indicate that a Fungible Token contract adheres to the current versions of this Metadata and the [Fungible Token Core](./Core.md) specs. This will allow consumers of the Fungible Token to know if they support the features of a given contract.
+- `spec`: a string. Should be `ft-1.0.0` to indicate that a Fungible Token contract adheres to the current versions of this Metadata and the [Fungible Token Core][FT Core] specs. This will allow consumers of the Fungible Token to know if they support the features of a given contract.
 - `name`: the human-readable name of the token.
 - `symbol`: the abbreviation, like wETH or AMPL.
 - `decimals`: used in frontends to show the proper significant digits of a token. This concept is explained well in this [OpenZeppelin post](https://docs.openzeppelin.com/contracts/3.x/erc20#a-note-on-decimals).
@@ -119,3 +119,5 @@ The `near-contract-standards` cargo package of the [Near Rust SDK](https://githu
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[FT Core]: ../specs/Standards/Tokens/FungibleToken/Core.md

--- a/neps/nep-0171.md
+++ b/neps/nep-0171.md
@@ -35,7 +35,7 @@ Prior art:
 
 - [ERC-721]
 - [EIP-1155 for multi-tokens](https://eips.ethereum.org/EIPS/eip-1155#non-fungible-tokens)
-- [NEAR's Fungible Token Standard](../FungibleToken/Core.md), which first pioneered the "transfer and call" technique
+- [NEAR's Fungible Token Standard][FT Core], which first pioneered the "transfer and call" technique
 
 
 ## Rationale and alternatives
@@ -51,7 +51,7 @@ Prior art:
 - All amounts, balances and allowance are limited by `U128` (max value `2**128 - 1`).
 - Token standard uses JSON for serialization of arguments and results.
 - Amounts in arguments and results are serialized as Base-10 strings, e.g. `"100"`. This is done to avoid JSON limitation of max integer value of `2**53`.
-- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard](../StorageManagement.md).
+- The contract must track the change in storage when adding to and removing from collections. This is not included in this core fungible token standard but instead in the [Storage Standard][Storage Management].
 - To prevent the deployed contract from being modified or deleted, it should not have any access keys on its account.
 
 ### NFT Interface
@@ -219,11 +219,11 @@ function nft_on_transfer(
 NEAR and third-party applications need to track `mint`, `transfer`, `burn` events for all NFT-driven apps consistently.
 This extension addresses that.
 
-Keep in mind that applications, including NEAR Wallet, could require implementing additional methods to display the NFTs correctly, such as [`nft_metadata`](Metadata.md) and [`nft_tokens_for_owner`](Enumeration.md).
+Keep in mind that applications, including NEAR Wallet, could require implementing additional methods to display the NFTs correctly, such as [`nft_metadata`][Metadata] and [`nft_tokens_for_owner`][NFT Enumeration]).
 
 ### Events Interface
 
-Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, and `data` must be of one of the following relavant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[]`:
+Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, and `data` must be of one of the following relevant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[]`:
 
 ```ts
 interface NftEventLogData {
@@ -367,8 +367,11 @@ Please feel free to open pull requests for extending the events standard detaile
   [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
   [storage staking]: https://docs.near.org/docs/concepts/storage-staking
   [gas]: https://docs.near.org/docs/concepts/gas
-  [Metadata]: Metadata.md
-  [Approval Management]: ApprovalManagement.md
+  [Metadata]: ../specs/Standards/Tokens/NonFungibleToken/Metadata.md
+  [Approval Management]: ../specs/Standards/Tokens/NonFungibleToken/ApprovalManagement.md
+  [FT core]: ../specs/Standards/Tokens/FungibleToken/Core.md
+  [Storage Management]: ../specs/Standards/StorageManagement.md
+  [NFT Enumeration]: ../specs/Standards/Tokens/NonFungibleToken/Enumeration.md
 
 ## Copyright
 [copyright]: #copyright

--- a/neps/nep-0171.md
+++ b/neps/nep-0171.md
@@ -364,16 +364,16 @@ Please feel free to open pull requests for extending the events standard detaile
 * **2021-12-20**: updated `nft_resolve_transfer` argument `approved_account_ids` to be type `null|Record<string, number>` instead of `null|string[]`. This gives contracts a way to restore the original approved accounts and their approval IDs. More information can be found in [this](https://github.com/near/NEPs/issues/301) discussion.
 * **2021-07-16**: updated `nft_transfer_call` argument `approval_id` to be type `number|null` instead of `string|null`. As stated, approval IDs are not expected to exceed the JSON limit of 2^53.
 
-  [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
-  [storage staking]: https://docs.near.org/docs/concepts/storage-staking
-  [gas]: https://docs.near.org/docs/concepts/gas
-  [Metadata]: ../specs/Standards/Tokens/NonFungibleToken/Metadata.md
-  [Approval Management]: ../specs/Standards/Tokens/NonFungibleToken/ApprovalManagement.md
-  [FT core]: ../specs/Standards/Tokens/FungibleToken/Core.md
-  [Storage Management]: ../specs/Standards/StorageManagement.md
-  [NFT Enumeration]: ../specs/Standards/Tokens/NonFungibleToken/Enumeration.md
-
 ## Copyright
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC-721]: https://eips.ethereum.org/EIPS/eip-721
+[storage staking]: https://docs.near.org/docs/concepts/storage-staking
+[gas]: https://docs.near.org/docs/concepts/gas
+[Metadata]: ../specs/Standards/Tokens/NonFungibleToken/Metadata.md
+[Approval Management]: ../specs/Standards/Tokens/NonFungibleToken/ApprovalManagement.md
+[FT core]: ../specs/Standards/Tokens/FungibleToken/Core.md
+[Storage Management]: ../specs/Standards/StorageManagement.md
+[NFT Enumeration]: ../specs/Standards/Tokens/NonFungibleToken/Enumeration.md

--- a/neps/nep-0177.md
+++ b/neps/nep-0177.md
@@ -16,7 +16,7 @@ An interface for a non-fungible token's metadata. The goal is to keep the metada
 
 ## Motivation
 
-The primary value of non-fungible tokens comes from their metadata. While the [core standard](Core.md) provides the minimum interface that can be considered a non-fungible token, most artists, developers, and dApps will want to associate more data with each NFT, and will want a predictable way to interact with any NFT's metadata.
+The primary value of non-fungible tokens comes from their metadata. While the [core standard][NFT Core] provides the minimum interface that can be considered a non-fungible token, most artists, developers, and dApps will want to associate more data with each NFT, and will want a predictable way to interact with any NFT's metadata.
 
 ## Rationale and alternatives
 
@@ -26,7 +26,7 @@ This standard also provides a `spec` version. This makes it easy for consumers o
 
 Prior art:
 
-- NEAR's [Fungible Token Metadata Standard](../FungibleToken/Metadata.md)
+- NEAR's [Fungible Token Metadata Standard][FT Metadata]
 - Discussion about NEAR's complete NFT standard: #171
 
 ## Specification
@@ -152,3 +152,6 @@ It gave those fields the type `string|null` but it was unclear whether it should
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[NFT Core]: ../specs/Standards/Tokens/NonFungibleToken/Core.md
+[FT Metadata]: ../specs/Standards/Tokens/FungibleToken/Metadata.md

--- a/neps/nep-0178.md
+++ b/neps/nep-0178.md
@@ -22,7 +22,7 @@ People familiar with [ERC-721] may expect to need an approval management system 
 
 ## Rationale and alternatives
 
-NEAR's [core Non-Fungible Token standard](Core.md) includes good support for safe atomic transfers without such complexity. It even provides "transfer and call" functionality (`nft_transfer_call`) which allows a specific token to be "attached" to a call to a separate contract. For many Non-Fungible Token workflows, these options may circumvent the need for a full-blown Approval Managament system.
+NEAR's [core Non-Fungible Token standard](Core.md) includes good support for safe atomic transfers without such complexity. It even provides "transfer and call" functionality (`nft_transfer_call`) which allows a specific token to be "attached" to a call to a separate contract. For many Non-Fungible Token workflows, these options may circumvent the need for a full-blown Approval Management system.
 
 However, some Non-Fungible Token developers, marketplaces, dApps, or artists may require greater control. This standard provides a uniform interface allowing token owners to approve other NEAR accounts, whether individuals or contracts, to transfer specific tokens on the owner's behalf.
 
@@ -226,7 +226,7 @@ Using near-cli:
       "token_id": "1",
     }' --accountId alice --depositYocto 1
 
-Note that `market` will not get a cross-contract call in this case. The implementors of the Market app should implement [cron](https://en.wikipedia.org/wiki/Cron)-type functionality to intermittently check that Market still has the access they expect.
+Note that `market` will not get a cross-contract call in this case. The implementers of the Market app should implement [cron](https://en.wikipedia.org/wiki/Cron)-type functionality to intermittently check that Market still has the access they expect.
 
 ### 7. Revoke all
 

--- a/neps/nep-0178.md
+++ b/neps/nep-0178.md
@@ -14,15 +14,13 @@ Requires: 171
 
 A system for allowing a set of users or contracts to transfer specific Non-Fungible Tokens on behalf of an owner. Similar to approval management systems in standards like [ERC-721].
 
-  [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
-
 ## Motivation
 
 People familiar with [ERC-721] may expect to need an approval management system for basic transfers, where a simple transfer from Alice to Bob requires that Alice first _approve_ Bob to spend one of her tokens, after which Bob can call `transfer_from` to actually transfer the token to himself.
 
 ## Rationale and alternatives
 
-NEAR's [core Non-Fungible Token standard](Core.md) includes good support for safe atomic transfers without such complexity. It even provides "transfer and call" functionality (`nft_transfer_call`) which allows a specific token to be "attached" to a call to a separate contract. For many Non-Fungible Token workflows, these options may circumvent the need for a full-blown Approval Management system.
+NEAR's [core Non-Fungible Token standard][NFT Core] includes good support for safe atomic transfers without such complexity. It even provides "transfer and call" functionality (`nft_transfer_call`) which allows a specific token to be "attached" to a call to a separate contract. For many Non-Fungible Token workflows, these options may circumvent the need for a full-blown Approval Management system.
 
 However, some Non-Fungible Token developers, marketplaces, dApps, or artists may require greater control. This standard provides a uniform interface allowing token owners to approve other NEAR accounts, whether individuals or contracts, to transfer specific tokens on the owner's behalf.
 
@@ -39,11 +37,11 @@ Let's consider some examples. Our cast of characters & apps:
 
 * Alice: has account `alice` with no contract deployed to it
 * Bob: has account `bob` with no contract deployed to it
-* NFT: a contract with account `nft`, implementing only the [Core NFT standard](Core.md) with this Approval Management extension
+* NFT: a contract with account `nft`, implementing only the [Core NFT standard][NFT Core] with this Approval Management extension
 * Market: a contract with account `market` which sells tokens from `nft` as well as other NFT contracts
 * Bazaar: similar to Market, but implemented differently (spoiler alert: has no `nft_on_approve` function!), has account `bazaar`
 
-Alice and Bob are already [registered](../StorageManagement.md) with NFT, Market, and Bazaar, and Alice owns a token on the NFT contract with ID=`"1"`.
+Alice and Bob are already [registered][Storage Management] with NFT, Market, and Bazaar, and Alice owns a token on the NFT contract with ID=`"1"`.
 
 Let's examine the technical calls through the following scenarios:
 
@@ -179,7 +177,7 @@ Not to worry, though, she checks `nft_is_approved` and sees that she did success
 
 ### 4. Approval IDs
 
-Bob buys Alice's token via Market. Bob probably does this via Market's frontend, which will probably initiate the transfer via a call to `ft_transfer_call` on the nDAI contract to transfer 100 nDAI to `market`. Like the NFT standard's "transfer and call" function, [Fungible Token](../FungibleToken/Core.md)'s `ft_transfer_call` takes a `msg` which `market` can use to pass along information it will need to pay Alice and actually transfer the NFT. The actual transfer of the NFT is the only part we care about here.
+Bob buys Alice's token via Market. Bob probably does this via Market's frontend, which will probably initiate the transfer via a call to `ft_transfer_call` on the nDAI contract to transfer 100 nDAI to `market`. Like the NFT standard's "transfer and call" function, [Fungible Token][FT Core]'s `ft_transfer_call` takes a `msg` which `market` can use to pass along information it will need to pay Alice and actually transfer the NFT. The actual transfer of the NFT is the only part we care about here.
 
 **High-level explanation**
 
@@ -469,3 +467,8 @@ NFT contracts should be implemented in a way to avoid extra gas fees for seriali
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC-721]: https://eips.ethereum.org/EIPS/eip-721
+[NFT Core]: ../specs/Standards/Tokens/NonFungibleToken/Core.md
+[Storage Management]: ../specs/Standards/StorageManagement.md
+[FT Core]: ../specs/Standards/Tokens/FungibleToken/Core.md

--- a/neps/nep-0181.md
+++ b/neps/nep-0181.md
@@ -80,10 +80,6 @@ function nft_tokens_for_owner(
 
 At the time of this writing, the specialized collections in the `near-sdk` Rust crate are iterable, but not all of them have implemented an `iter_from` solution. There may be efficiency gains for large collections and contract developers are encouraged to test their data structures with a large amount of entries. 
 
-  [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
-  [storage]: https://docs.near.org/docs/concepts/storage-staking
-
-
 ## Reference Implementation
 
 [Minimum Viable Interface](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/non_fungible_token/enumeration/mod.rs)
@@ -94,3 +90,6 @@ At the time of this writing, the specialized collections in the `near-sdk` Rust 
 [copyright]: #copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC-721]: https://eips.ethereum.org/EIPS/eip-721
+[storage]: https://docs.near.org/docs/concepts/storage-staking

--- a/neps/nep-0245.md
+++ b/neps/nep-0245.md
@@ -21,7 +21,7 @@ In the three years since [ERC-1155] was ratified by the Ethereum Community, Mult
 
 Having a single contract represent NFTs, FTs, and tokens that sit inbetween greatly improves efficiency. The standard also introduced the ability to make batch requests with multiple asset classes reducing complexity. This standard allows operations that currently require _many_ transactions to be completed in a single transaction that can transfer not only NFTs and FTs, but any tokens that are a part of same token contract.
 
-With this standard, we have sought to take advantage of the ability of the NEAR blockchain to scale. Its sharded runtime, and [storage staking] model that decouples [gas] fees from storage demand, enables ultra low transaction fees and greater on chain storage ( see [Metadata] extension).   
+With this standard, we have sought to take advantage of the ability of the NEAR blockchain to scale. Its sharded runtime, and [storage staking] model that decouples [gas] fees from storage demand, enables ultra low transaction fees and greater on chain storage (see [Metadata][MT Metadata] extension).   
 
 With the aforementioned, it is noteworthy to mention that like the [NFT] standard the Multi Token standard, implements `mt_transfer_call`,
 which allows, a user to attach many tokens to a call to a separate contract. Additionally, this standard includes an optional [Approval Management] extension. The extension allows marketplaces to trade on behalf of a user, providing additional flexibility for dApps.
@@ -30,8 +30,8 @@ Prior art:
 
 - [ERC-721]
 - [ERC-1155]
-- [NEAR Fungible Token Standard][FT], which first pioneered the "transfer and call" technique
-- [NEAR Non-Fungible Token Standard][NFT]
+- [NEAR Fungible Token Standard][FT Core], which first pioneered the "transfer and call" technique
+- [NEAR Non-Fungible Token Standard][NFT Core]
 
 ## Rationale and alternatives
 
@@ -43,7 +43,7 @@ The decision to not use FT and NFT as explicit token types was taken to allow th
 
 The issues with this in general is a problem with defining what metadata means and how is that interpreted. We have chosen to follow the pattern that is currently in use on Ethereum in the [ERC-1155] standard. That pattern relies on people to make extensions or to make signals as to how they want the metadata to be represented for their use case. 
 
-One of the areas that has broad sweeping implications from the [ERC-1155] standard is the lack of direct access to metadata. With Near's sharding we are able to have a [Metadata Extension](Metadata.md) for the standard that exists on chain. So developers and users are not required to use an indexer to understand, how to interact or interpret tokens, via token identifiers that they receive.
+One of the areas that has broad sweeping implications from the [ERC-1155] standard is the lack of direct access to metadata. With Near's sharding we are able to have a [Metadata Extension][MT Metadata] for the standard that exists on chain. So developers and users are not required to use an indexer to understand, how to interact or interpret tokens, via token identifiers that they receive.
 
 Another extension that we made was to provide an explicit ability for developers and users to group or link together series of NFTs/FTs or any combination of tokens. This provides additional flexibility that the  [ERC-1155] standard only has loose guidelines on. This was chosen to make it easy for consumers to understand the relationship between tokens within the contract. 
 
@@ -55,7 +55,7 @@ To recap, we choose to create this standard, to improve interoperability, develo
 - All amounts, balances and allowance are limited by `U128` (max value `2**128 - 1`).
 - Token standard uses JSON for serialization of arguments and results.
 - Amounts in arguments and results are serialized as Base-10 strings, e.g. `"100"`. This is done to avoid JSON limitation of max integer value of `2**53`.
-- The contract must track the change in storage when adding to and removing from collections. This is not included in this core multi token standard but instead in the [Storage Standard](../StorageManagement.md). 
+- The contract must track the change in storage when adding to and removing from collections. This is not included in this core multi token standard but instead in the [Storage Standard][Storage Management]. 
 - To prevent the deployed contract from being modified or deleted, it should not have any access keys on its account.
 
 ### MT Interface
@@ -397,10 +397,10 @@ function mt_on_transfer(
 NEAR and third-party applications need to track
  `mint`, `burn`, `transfer` events for all MT-driven apps consistently. This exension addresses that.
 
-Note that applications, including NEAR Wallet, could require implementing additional methods to display tokens correctly such as [`mt_metadata`](Metadata.md) and [`mt_tokens_for_owner`](Enumeration.md).
+Note that applications, including NEAR Wallet, could require implementing additional methods to display tokens correctly such as [`mt_metadata`][MT Metadata] and [`mt_tokens_for_owner`][MT Enumeration].
 
 ### Events Interface
-Multi Token Events MUST have `standard` set to `"nep245"`, standard version set to `"1.0.0"`, `event` value is one of `mt_mint`, `mt_burn`, `mt_transfer`, and `data` must be of one of the following relavant types: `MtMintLog[] | MtBurnLog[] | MtTransferLog[]`:
+Multi Token Events MUST have `standard` set to `"nep245"`, standard version set to `"1.0.0"`, `event` value is one of `mt_mint`, `mt_burn`, `mt_transfer`, and `data` must be of one of the following relevant types: `MtMintLog[] | MtBurnLog[] | MtTransferLog[]`:
 
 
 
@@ -554,9 +554,9 @@ EVENT_JSON:{
 
 Note that the example events covered above cover two different kinds of events:
 1. Events that are not specified in the MT Standard (`mt_mint`, `mt_burn`)
-2. An event that is covered in the [Multi Token Core Standard](https://nomicon.io/Standards/MultiToken/Core.html#mt-interface). (`mt_transfer`)
+2. An event that is covered in the [Multi Token Core Standard](https://nomicon.io/Standards/Tokens/MultiToken/Core#mt-interface). (`mt_transfer`)
 
-This event standard also applies beyond the three events highlighted here, where future events follow the same convention of as the second type. For instance, if an MT contract uses the [approval management standard](https://nomicon.io/Standards/MultiToken/ApprovalManagement.html), it may emit an event for `mt_approve` if that's deemed as important by the developer community.
+This event standard also applies beyond the three events highlighted here, where future events follow the same convention of as the second type. For instance, if an MT contract uses the [approval management standard](https://nomicon.io/Standards/Tokens/MultiToken/ApprovalManagement), it may emit an event for `mt_approve` if that's deemed as important by the developer community.
 
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.
 
@@ -573,11 +573,13 @@ Please feel free to open pull requests for extending the events standard detaile
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-  [ERC-721]: https://eips.ethereum.org/EIPS/eip-721
-  [ERC-1155]: https://eips.ethereum.org/EIPS/eip-1155
-  [storage staking]: https://docs.near.org/docs/concepts/storage-staking
-  [gas]: https://docs.near.org/docs/concepts/gas
-  [Metadata]: ../specs/Standards/MultiToken/Metadata.md
-  [NFT]: ../specs/Standards/NonFungibleToken/Core.md
-  [Approval Management]: ../specs/Standards/MultiToken/ApprovalManagement.md
-  [FT]: ../specs/Standards/FungibleToken/Core.md
+[ERC-721]: https://eips.ethereum.org/EIPS/eip-721
+[ERC-1155]: https://eips.ethereum.org/EIPS/eip-1155
+[storage staking]: https://docs.near.org/docs/concepts/storage-staking
+[gas]: https://docs.near.org/docs/concepts/gas
+[MT Metadata]: ../specs/Standards/Tokens/MultiToken/Metadata.md
+[NFT Core]: ../specs/Standards/Tokens/NonFungibleToken/Core.md
+[Approval Management]: ../specs/Standards/MultiToken/ApprovalManagement.md
+[FT Core]: ../specs/Standards/Tokens/FungibleToken/Core.md
+[Storage Management]: ../specs/Standards/StorageManagement.md
+[MT Enumeration]: ../specs/Standards/Tokens/MultiToken/Enumeration.md

--- a/neps/nep-0245.md
+++ b/neps/nep-0245.md
@@ -45,7 +45,7 @@ The issues with this in general is a problem with defining what metadata means a
 
 One of the areas that has broad sweeping implications from the [ERC-1155] standard is the lack of direct access to metadata. With Near's sharding we are able to have a [Metadata Extension](Metadata.md) for the standard that exists on chain. So developers and users are not required to use an indexer to understand, how to interact or interpret tokens, via token identifiers that they receive.
 
-Another extension that we made was to provide an explicit ability for developers and users to group or link together series of NFTs/FTs or any combination of tokens. This provides additional flexiblity that the  [ERC-1155] standard only has loose guidelines on. This was chosen to make it easy for consumers to understand the relationship between tokens within the contract. 
+Another extension that we made was to provide an explicit ability for developers and users to group or link together series of NFTs/FTs or any combination of tokens. This provides additional flexibility that the  [ERC-1155] standard only has loose guidelines on. This was chosen to make it easy for consumers to understand the relationship between tokens within the contract. 
 
 To recap, we choose to create this standard, to improve interoperability, developer ease of use, and to extend token representability beyond what was available directly in the FT or NFT standards. We believe this to be another tool in the developer's toolkit. It makes it possible to represent many types of tokens and to enable exchanges of many tokens within a single `transaction`. 
 

--- a/neps/nep-0297.md
+++ b/neps/nep-0297.md
@@ -60,7 +60,7 @@ interface EventLogData {
 }
 ```
 
-Thus, to emit an event, you only need to log a string following the rules above. Here is a bare bones example using Rust SDK `near_sdk::log!` macro (security note: prefer using `serde_json` or alternatives to serialize the JSON string to avoid potential injections and corrupted events):
+Thus, to emit an event, you only need to log a string following the rules above. Here is a bare-bones example using Rust SDK `near_sdk::log!` macro (security note: prefer using `serde_json` or alternatives to serialize the JSON string to avoid potential injections and corrupted events):
 ```rust
 use near_sdk::log;
 

--- a/neps/nep-0297.md
+++ b/neps/nep-0297.md
@@ -60,7 +60,7 @@ interface EventLogData {
 }
 ```
 
-Thus, to emit an event, you only need to log a string following the rules above. Here is a barebones example using Rust SDK `near_sdk::log!` macro (security note: prefer using `serde_json` or alternatives to serialize the JSON string to avoid potential injections and corrupted events):
+Thus, to emit an event, you only need to log a string following the rules above. Here is a bare bones example using Rust SDK `near_sdk::log!` macro (security note: prefer using `serde_json` or alternatives to serialize the JSON string to avoid potential injections and corrupted events):
 ```rust
 use near_sdk::log;
 


### PR DESCRIPTION
I've noticed several urls were broken on the NEPs so I had a go at all of them This PR updates the urls  and moves them as references at the bottom of the md Files. 
This improves on DRY and will help updating them in future. 

Few questions: 
Where shall https://github.com/near/NEPs/blob/master/neps/nep-0021.md#reference-implementation url point to ?
Shall we move all mentioned urls as refs at the bottom of the page (currently the NEPs use mixed approach, this pr makes all urls pointing to local(to repository) urls as refs)? 
