### PR TITLE
Typo in TokenMetadata

### DIFF
--- a/specs/Standards/Tokens/NonFungibleToken/Metadata.md
+++ b/specs/Standards/Tokens/NonFungibleToken/Metadata.md
@@ -85,7 +85,7 @@ For `NFTContractMetadata`:
 
 For `TokenMetadata`:
 
-- `name`:  The name of this specific token.
+- `title`:  The name of this specific token.
 - `description`: A longer description of the token.
 - `media`: URL to associated media. Preferably to decentralized, content-addressed storage.
 - `media_hash`: the base64-encoded sha256 hash of content referenced by the `media` field. This is to guard against off-chain tampering.


### PR DESCRIPTION
Fixing this typo cause it's a bit confusing as it might lead to thinking that `title` prop has been renamed to `name` in new specs, but it seems to be indeed just a typo.