### PR TITLE
Updating NEP-141 authors

### DIFF
--- a/neps/nep-0141.md
+++ b/neps/nep-0141.md
@@ -1,7 +1,7 @@
 ---
 NEP: 141
 Title: Fungible Token Standard
-Author: Evgeny Kuzyakov <ek@near.org>, @oysterpack
+Author: Evgeny Kuzyakov <ek@near.org>, Robert Zaremba <@robert-zaremba>, @oysterpack
 DiscussionsTo: https://github.com/near/NEPs/issues/141
 Status: Final
 Type: Standards Track


### PR DESCRIPTION
NEP-141 came through my proposal https://github.com/near/NEPs/issues/136 as a more robust Interface for Fungible Tokens and reflection from the previous NEP-122. 
Prior to that we were discussing the pitfalls for ERC20 and a better solution that would serve NEAR ecosystem needs. See Rationale described in https://github.com/near/NEPs/issues/136. I was part of the core working group (together with Evgeny, @oysterpack, @luciotato, @mikedotexe  ) designing the NEP-141, where we hardened the NEP-136 design by analyzing the storage use cases and metadata management.