### PR TITLE
Clarify reference and draft implementation

### DIFF
--- a/neps/nep-0001.md
+++ b/neps/nep-0001.md
@@ -99,8 +99,7 @@ The NEP process has various roles and responsibilities.
 - Submits proposal with prototype when ready for review and changes the status to “Draft”
 - Addresses comments
 - Presents to working group and incorporates necessary changes
-- Executes implementation once approved
-- Provides reference implementation and documentation once approved
+- Provides final implementation with sufficient testing and documentation once approved
 
 ![Moderator](https://user-images.githubusercontent.com/110252255/181816650-b1610c0e-6d32-4d2a-a34e-877c702139bd.png)
 **Moderator**<br />
@@ -138,8 +137,8 @@ Each NEP should have the following parts/sections:
 1. Motivation - The motivation section should clearly explain why the existing contract ecosystem is inadequate to address the problem that the NEP solves. This can include collecting documented support for the NEP from important projects in the NEAR ecosystem. NEP submissions without sufficient motivation may be rejected.
 1. Rationale and alternatives - The rationale fleshes out the specification by describing why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other platforms.
 1. Specification - The technical specification should describe the syntax and semantics of the contract or protocol feature. The specification should be detailed enough to allow competing, interoperable implementations for at least the current major NEAR version.
-1. Reference Implementation - The reference implementation must be completed before any NEP is given the “Approved” status.
-   While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of “rough consensus and running code” is still useful when it comes to resolving many discussions of API details. The final implementation must include test code and documentation. 
+1. Draft Implementation - A draft implementation showing the viability of the proposal must be completed before any NEP is given the “Approved” status.
+   While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of “rough consensus and running code” is still useful when it comes to resolving many discussions of API details. Once approved, the final implementation must include test code and documentation.
 1. Security Implications - If there are security concerns in relation to the NEP, those concerns should be explicitly written out to make sure reviewers of the NEP are aware of them.
 1. Drawbacks - Throughout the discussion of a NEP, various ideas will be proposed which are not accepted. Those rejected ideas should be recorded along with the reasoning as to why they were rejected. This both helps record the thought process behind the final version of the NEP as well as preventing people from bringing up the same rejected idea again in subsequent discussions.
    In a way this section can be thought of as a breakout section of the Rationale section that is focused specifically on why certain ideas were not ultimately pursued.


### PR DESCRIPTION
I believe this document uses the term "reference implementation" to mean "draft implementation".  Given that we say that `nearcore` is the reference implementation of the protocol, this PR rewords "reference implementation" to "draft implementation" to clarify the intend.  
