### PR TITLE
NEP-417: Meta transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Changes to the protocol specification and standards are called NEAR Enhancement 
 |[0245](https://github.com/near/NEPs/blob/master/neps/nep-0245.md)   | Multi Token Standard | @zcstarr @riqi @jriemann @marcos.sun | Review |
 |[0297](https://github.com/near/NEPs/blob/master/neps/nep-0297.md)   | Events Standard | @telezhnaya | Final |
 |[0330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)   | Source Metadata | @BenKurrek | Review |
-|[0366](https://github.com/near/NEPs/blob/master/neps/nep-0000.md) | Meta Transactions | @ilblackdragon | Draft |
+|[0366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md)   | Meta Transactions | @ilblackdragon @e-uleyskiy @fadeevab | Draft |
 
 
 
@@ -69,7 +69,7 @@ Spec changes are ultimately done via pull requests to this repository (formalize
     ```
 
    * Once complete, submit the pull request for editor review.
-  
+
    * The formalization dance begins:
      * NEP Editors, who are unopinionated shepherds of the process, check document formatting, completeness and adherence to [NEP-0001](neps/nep-0001.md) and approve the pull request.
      * Once ready, the author updates the NEP status to `Review` allowing further community participation, to address any gaps or clarifications, normally part of the Review PR.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Changes to the protocol specification and standards are called NEAR Enhancement 
 |[0245](https://github.com/near/NEPs/blob/master/neps/nep-0245.md)   | Multi Token Standard | @zcstarr @riqi @jriemann @marcos.sun | Review |
 |[0297](https://github.com/near/NEPs/blob/master/neps/nep-0297.md)   | Events Standard | @telezhnaya | Final |
 |[0330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)   | Source Metadata | @BenKurrek | Review |
+|[0366](https://github.com/near/NEPs/blob/master/neps/nep-0000.md) | Meta Transactions | @ilblackdragon | Draft |
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Changes to the protocol specification and standards are called NEAR Enhancement 
 |[0245](https://github.com/near/NEPs/blob/master/neps/nep-0245.md)   | Multi Token Standard | @zcstarr @riqi @jriemann @marcos.sun | Review |
 |[0297](https://github.com/near/NEPs/blob/master/neps/nep-0297.md)   | Events Standard | @telezhnaya | Final |
 |[0330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)   | Source Metadata | @BenKurrek | Review |
-|[0366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md)   | Meta Transactions | @ilblackdragon @e-uleyskiy @fadeevab | Draft |
+|[0417](https://github.com/near/NEPs/blob/master/neps/nep-0417.md)   | Meta Transactions | @ilblackdragon @e-uleyskiy @fadeevab | Draft |
 
 
 

--- a/neps/nep-0366.md
+++ b/neps/nep-0366.md
@@ -1,12 +1,12 @@
 ---
 NEP: 366
 Title: Meta Transactions
-Author: Illia Polosukhin <ilblackdragon@gmail.com>
+Author: Illia Polosukhin <ilblackdragon@gmail.com>, Egor Uleyskiy (egor.ulieiskii@gmail.com), Alexander Fadeev (fadeevab.com@gmail.com)
 DiscussionsTo: https://github.com/nearprotocol/neps/pull/366
 Status: Draft
 Type: Protocol Track
 Category: Runtime
-Created: 21-Jun-2022
+Created: 19-Oct-2022
 ---
 
 ## Summary
@@ -32,13 +32,19 @@ This design has severe limitations as it requires the user to deploy such contra
 ## Specification
 
 The main flow of the meta transaction will be as follows:
- - User signs a `DelegateActionMessage` specifying the set of actions that they need to be executed. It will also specify a relayer to ensure secure execution.
- - User sends the signed `DelegateAction` data to the relayer.
- - Relayer forms a `Transaction` with `receiver_id` equal to the user's account and `actions: [DelegateAction { ... }]` and signs it with it's key. Note that such transactions can contain other actions toward user's account (for example calling a function).
+ - User requests the relayer for its access key (public key) which the relayer are going to use. The user specifies this key as `relayer_pub_key` in `DelegateAction`.
+ - User fetches the relayer's access key `nonce`, increments it and assigns the value to `relayer_nonce` in `DelegateAction`: `relayer_nonce = nonce + 1`.
+ - User specifies `sender_id` (the user's account id) and `relayer_id` in `DelegateAction`.
+ - User signs `DelegateAction` specifying the set of actions that they need to be executed.
+ - User forms `SignedDelegateAction` with the `DelegateAction` and the `DelegateAction` signature.
+ - User forms `DelegateActionMessage` with the `SignedDelegateAction`.
+ - User sends `DelegateActionMessage` data to the relayer.
+ - Relayer verifies actions specified in `DelegateAction`: the total cost and whether the user included the reward for the relayer.
+ - Relayer forms a `Transaction` with `receiver_id` equals to `delegate_action.sender_id` and `actions: [SignedDelegateAction { ... }]`. Signs it with its key. Note that such transactions can contain other actions toward user's account (for example calling a function).
  - This transaction is processed normally. A `Receipt` is created with a copy of the actions in the transaction.
- - When processing a `DelegateAction`, a number of checks are done (see below), mainly a check to ensure that the `signature` matches the user account's key.
- - When a `Receipt` with a valid `DelegateAction` in actions arrives at the user's account, it gets executed. Execution means creation of a new Receipt with `receiver_id: AccountId` and `actions: Action` matching `receiver_id` and `actions` in the `DelegateAction`.
- - The new `Receipt` looks like a normal receipt that could have originated from the user's account, with `predeccessor_id` equal to user's account.
+ - When processing a `SignedDelegateAction`, a number of checks are done (see below), mainly a check to ensure that the `signature` matches the user account's key.
+ - When a `Receipt` with a valid `SignedDelegateAction` in actions arrives at the user's account, it gets executed. Execution means creation of a new Receipt with `receiver_id: AccountId` and `actions: Action` matching `receiver_id` and `actions` in the `DelegateAction`.
+ - The new `Receipt` looks like a normal receipt that could have originated from the user's account, with `predeccessor_id` equal to tbe user's account, `signer_id` equal to the relayer's account, `signer_public_key` equal to the relayer's public key.
 
 ### DelegateAction
 
@@ -46,17 +52,33 @@ Delegate actions allows for an account to initiate a batch of actions on behalf 
 
 ```rust
 pub struct DelegateAction {
+    /// Relayer which should submit ansthe delegated actions
+    relayer_id: AccountId,
+    /// Relayer's public key which should be used for the transaction
+    relayer_pub_key: PublicKey,
+    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `relayer_pub_key`.
+    /// This nonce is used if `sender_id` account doesn't exist.
+    relayer_nonce: Nonce,
+    /// Signer of the delegated actions
+    sender_id: AccountId,
     /// Receiver of the delegated actions.
     receiver_id: AccountId,
     /// List of actions to be executed.
     actions: Vec<Action>,
-
+    /// Block hash to ensure validity.
+    block_hash: CryptoHash,
     /// Public key that is used to sign this delegated action.
-    signer_pk: PublicKey,
-    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `signer_pk`.
+    public_key: PublicKey,
+    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `public_key`.
     /// After this action is processed it will increment.
     nonce: Nonce,
-    /// Signature of the originating user signing `DelegateActionMessage` formed out of the data in the `DelegateAction`.
+}
+```
+
+```rust
+pub struct SignedDelegateAction {
+    delegate_action: DelegateAction,
+    /// Signature of the `DelegateAction`.
     signature: Signature,
 }
 ```
@@ -64,62 +86,93 @@ pub struct DelegateAction {
  Supporting batches of `actions` means `DelegateAction` can be used initiate a complex steps like creating new accounts, transferring funds, deploying contracts, and executing an initialization function all within the same transaction.
 
 ***Validation***:
-To ensure that a `DelegateAction` is correct, on receipt the following signature verification is performed: `verify_signature(hash(message), signer_pk, signature)`.
+1. Validate `DelegateAction` doesn't contain a nested `DelegateAction` in actions.
+2. To ensure that a `DelegateAction` is correct, on receipt the following signature verification is performed: `verify_signature(hash(delegate_action), delegate_action.public_key, signature)`.
+3. Verify `transaction.receiver_id` matches `delegate_action.sender_id`.
+4. Verify `delegate_action.block_hash`.
+5. If `delegate_action.sender_id` doesn't exist:
+    1. Verify `transaction.signer_id == delegate_action.relayer_id`.
+    2. Verify `transaction.public_key == delegate_action.relayer_pub_key`.
+    3. Verify `transaction.nonce == delegate_action.relayer_nonce`.
+    4. Verify `delegate_action.relayer_nonce - 1 == relayer.access_key.nonce`.
+6. If `delegate_action.sender_id` exists:
+    1. Verify `delegate_action.sender_id` owns `delegate_action.public_key`.
+    2. Verify `delegate_action.nonce > sender.access_key.nonce`.
 
-A `message` is formed in the following format and it must be signed by the user:
+A `message` is formed in the following format:
 ```rust
 struct DelegateActionMessage {
-    /// If not None, then should match the `predecessor_id` that created the `DelegateAction`.
-    sender_id: Option<AccountId>,
-    /// Matching the given account_id.
-    signer_id: AccountId,
-    /// Should match the `signer_pk` from the `DelegateAction`.
-    public_key: PublicKey,
-    /// Nonce for the given `public_key` from the `DelegateAction`.
-    nonce: Nonce,
-    /// Should match the `receiver_id` from the `DelegateAction`.
-    receiver_id: AccountId,
-    /// Block hash to ensure validity.
-    block_hash: CryptoHash,
-    /// Should match `actions` from the `DelegateAction`.
-    actions: Vec<Action>,
+    delegate_action: DelegateAction,
+    signature: Signature,
 }
 ```
 
 The next set of security concerns are addressed by this format:
- - If format matches `Transaction`, then the relayer can just send it directly, not receiving payment.
- - Because the set of actions can include payment for the relayer (for example in FT), the `sender_id` is added directly into the message to ensure that nobody else can send this message.
- - `nonce` is included to ensure that this message can't be replayed again.
- - `public_key` and `signer_id` are needed to ensure the on the right account, work across rotating keys and fetch correct `nonce`.
+ - `relayer_id` is included to ensure noone else can send `DelegateAction`.
+ - `relayer_pub_key` and `relayer_nonce` is included to ensure that `DelegateAction` can't be replayed again.
+ - `sender_id` is included to ensure that the relayer set correct `transaction.receiver_id`.
+ - `block_hash` is included to ensure that the `DelegateAction` isn't expired.
+ - `nonce` is included to ensure that the `DelegateAction` can't be replayed again.
+ - `public_key` and `sender_id` are needed to ensure that on the right account, work across rotating keys and fetch correct `nonce`.
 
-The permissions are verified based on the variant of `signer_pk`:
+The permissions are verified based on the variant of `public_key`:
  - `AccessKeyPermission::FullAccess`, all actions are allowed.
  - `AccessKeyPermission::FunctionCall`, only a single `FunctionCall` action is allowed in `actions`.
     - `DelegateAction.receiver_id` must match to the `account[public_key].receiver_id`
     - `DelegateAction.actions[0].method_name` must be in the `account[public_key].method_names`
 
 ***Outcomes***:
-- If the `signature` matches the receiver's account's `signer_pk`, a new receipt is created from this account with a set of `ActionReceipt { receiver_id, action }` for each action in `actions`.
+- If the `signature` matches the receiver's account's `public_key`, a new receipt is created from this account with a set of `ActionReceipt { receiver_id, action }` for each action in `actions`.
 
 #### Errors
 
 **Validation Error**
-- If the `signer_pk` does not exist for the given account, the following error will be returned
-```rust
-/// Signer key for delegate action is missing from the given account
-DelegateActionSignerDoesNotExist
-```
 
-- If the `nonce` does not exist match the `signer_pk` for the `receiver_id`, the the following error will be returned
-```rust
-/// Nonce must be account[signer_pk].nonce + 1
-DelegateActionInvalidNonce
-```
-
-- If the `signature` does not match the data and the `signer_pk` of the given key, then the following error will be returned
+- If the `signature` does not match the data and the `public_key` of the given key, then the following error will be returned
 ```rust
 /// Signature does not match the provided actions and given signer public key.
 DelegateActionInvalidSignature
+```
+- If the `sender_id` doesn't match the `tx.receiver_id`
+```rust
+/// Receiver of the transaction doesn't match Sender of the delegate action
+DelegateActionSenderDoesNotMatchReceiver
+```
+
+- If `block_hash` is too old
+```rust
+/// Delegate action has expired
+DelegateActionExpired
+```
+
+- If the `relayer_id` doesn't match `tx.signer_id`
+```rust
+/// Relayer doesn't match Signer of the transaction
+DelegateActionRelayerDoesNotMatchSigner
+```
+
+- If `relayer_pub_key` doesn't match `tx.public_key`
+```rust
+/// Relayer's public key doesn't match the key used in the transaction
+DelegateActionInvalidRelayerKey
+```
+
+- If the `relayer_nonce` doesn't match `tx.nonce` or `relayer_nonce - 1 != relayer[relayer_pub_key].nonce`
+```rust
+/// The nonce must match tx,nonce and must be relayer[relayer_pub_key].nonce + 1
+DelegateActionInvalidRelayerNonce
+```
+
+- If the `public_key` does not exist for the given account, the following error will be returned
+```rust
+/// The given public key doesn't match Sender account
+DelegateActionPublicKeyDoesNotExist
+```
+
+- If the `nonce` does not exist match the `public_key` for the `sender_id`, the the following error will be returned
+```rust
+/// Nonce must be sender[public_key].nonce + 1
+DelegateActionInvalidNonce
 ```
 
 
@@ -127,7 +180,7 @@ See the [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateActi
 
 ## Security Implications
 
-Delegate actions do not override `signer_pk`, leaving that to the original signer that initiated transaction (e.g. the relayer in the meta transaction case). Although it is possible to override the `signer_pk` in the context with one from the `DelegateAction`, there is no clear value in that.
+Delegate actions do not override `signer_public_key`, leaving that to the original signer that initiated transaction (e.g. the relayer in the meta transaction case). Although it is possible to override the `signer_public_key` in the context with one from the `DelegateAction`, there is no clear value in that.
 
 See the ***Validation*** section in [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateAction) for security considerations around what the user signs and the validation of actions with different permissions.
 

--- a/neps/nep-0366.md
+++ b/neps/nep-0366.md
@@ -1,0 +1,148 @@
+---
+NEP: 366
+Title: Meta Transactions
+Author: Illia Polosukhin <ilblackdragon@gmail.com>
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/366
+Status: Draft
+Type: Protocol Track
+Category: Runtime
+Created: 21-Jun-2022
+---
+
+## Summary
+
+In-protocol meta transactions allowing for third-party account to initiate and pay transaction fees on behalf of the account.
+
+## Motivation
+
+NEAR has been designed with simplicity of onboarding in mind. One of the large hurdles right now is that after creating an implicit or even named account the user does not have NEAR to pay gas fees to interact with apps.
+
+For example, apps that pay user for doing work (like NEARCrowd or Sweatcoin) or free-to-play games.
+
+[Aurora Plus](https://aurora.plus) has shown viability of the relayers that can offer some number of free transactions and a subscription model. Shifting the complexity of dealing with fees to the infrastructure from the user space.
+
+## Rationale and alternatives
+
+Proposed here design provides the easiest for users and developers way to onboard and pay for user transactions.
+There is no requirement on the user account, including user account may not even exist on chain and implicit account can be used.
+
+An alternative is proxy contracts deployed on the user account.
+This design has severe limitations as it requires user to deploy such contract and additional costs for storage.
+
+## Specification
+
+The main flow of the meta transaction will be as follows:
+ - User will sign `DelegateActionMessage` specifying set of actions that they need to be executed. It also includes specific relayer to ensure secure execution.
+ - User sends signed `DelegateAction` data to the relayer
+ - Relayer forms a `Transaction` with `receiver_id` equal to the user's account and `actions: [DelegateAction { ... }]`, and signs it with it's key. Note, that such transaction can contain other actions toward user's account (for example calling a function).
+ - This transaction is processed normally, by creating a receipt with copy of the all the actions into the `Receipt`.
+ - When processing `DelegateAction` a number of checks are done (see below), mainly `signature` matching user account's key.
+ - When such `Receipt` with valid `DelegateAction` in actions arrives to the user's account it gets executed. The executed means creation of a new Receipt with `receiver_id: AccountId`, `actions: Action` matching `receiver_id` and `actions` inside `DelegateAction`. 
+ - The new `Receipt` looks like normal receipt that would have been originating from user's account, with `predeccessor_id` equal to user's account.
+
+### DelegateAction
+
+Delegate action allows for an account to initiate a batch of actions on behalf of the receiving account, allowing to proxy actions. This is used in implementation of meta transactions.
+
+```rust
+pub struct DelegateAction {
+    /// Receiver of the delegated actions.
+    receiver_id: AccountId,
+    /// List of actions to be executed.
+    actions: Vec<Action>,
+ 
+    /// Public key that is used to sign this delegated action.
+    signer_pk: PublicKey,
+    /// Nonce is used to determine that the same delegate action is not sent twice by relayers and should match for given account's `signer_pk`. 
+    /// After this action is processed it will increment.
+    nonce: Nonce,
+    /// Signature of the originating user signing `DelegateActionMessage` formed out of the data in the `DelegateAction`.
+    signature: Signature,
+}
+```
+
+ Supporting a batch of `actions` means `DelegateAction` can initiate a complex steps like creating a new account and transferring funds, deploying a contract and executing an initialization function.
+
+***Validation***:
+To ensure that `DelegateAction` is correct, on receival the verification of signature is done: `verify_signature(hash(message), signer_pk, signature)`.
+
+The `message` is formed in the next format and must be signed by the user:
+```rust
+struct DelegateActionMessage {
+    /// If not None, should match the `predecessor_id` that have created `DelegateAction`.
+    sender_id: Option<AccountId>,
+    /// Matching the given account_id.
+    signer_id: AccountId,
+    /// Matching the `signer_pk` from `DelegateAction`.
+    public_key: PublicKey,
+    /// Nonce for the given `public_key` from `DelegateAction`.
+    nonce: Nonce,
+    /// Matching the `receiver_id` from `DelegateAction`.
+    receiver_id: AccountId,
+    /// Block hash to ensure validity.
+    /// Actions matching `actions` from `DelegateAction`.
+    actions: Vec<Action>,
+}
+```
+
+The next set of security concerns are addressed by this format:
+ - If format matches `Transaction`, the relayer can just send it directly, not receiving payment.
+ - Because set of actions can include pay back to the relayer (for example by paying in FT), the `sender_id` is added directly into the message to ensure that nobody else can send this message.
+ - `nonce` is included to ensure that this message can't be replayed again.
+ - `public_key` and `signer_id` are needed to ensure the on the right account, work across rotating keys and fetch correct `nonce`.
+
+The permissions are verified based on kind `AccessKeyPermission` of `signer_pk`:
+ - `AccessKeyPermission::FullAccess`, all actions are allowed.
+ - `AccessKeyPermission::FunctionCall`, only a single `FunctionCall` action is allowed in `actions`. 
+    - `DelegateAction.receiver_id` must match to the `account[public_key].receiver_id`
+    - `DelegateAction.actions[0].method_name` must be in the `account[public_key].method_names`
+
+***Outcomes***:
+- If `signature` matches receiver's accounts `signer_pk`, new receipt is created from this account with set of `ActionReceipt { receiver_id, action }` for each item in `actions`. 
+
+#### Errors
+
+**Validation Error**
+- If `signer_pk` does not exist for the given account, the following error will be returned
+```rust
+/// Signer key for delegate action is missing from given account
+DelegateActionSignerDoesNotExist
+```
+
+- If `nonce` does not exist match `signer_pk` for  `receiver_id`, the following error will be returned
+```rust
+/// Nonce must be account[signer_pk].nonce + 1
+DelegateActionInvalidNonce
+```
+
+- If `signature` does not match to the data and `signer_pk` of the given key, the following error will be returned
+```rust
+/// Signature does not match the provided actions and given signer public key.
+DelegateActionInvalidSignature
+```
+
+
+See the [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateAction) for details.
+
+## Security Implications
+
+Delegate actions do not override `signer_pk`, leaving that to the original signer that initiated transaction (eg relayer in meta transaction case). Although it is possible to override `signer_pk` in the context with one from `DelegateAction`, there is no clear value to do that.
+
+See ***Validation*** section in [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateAction) for security considerations around what user signs and validation of actions with different permissions.
+
+## Drawbacks
+
+Increases complexity of the the NEAR's transactional model.
+
+Meta transactions take an extra block to execute, as they first need to be included by the originating account, then routed to the delegate account and only after that to the real destination.
+
+Delegate actions are not programmable as they require having signatures. Original proposal contained a new `AccessKey` kind that would support programmable delegated actions. On the other hand, that would be limiting without programmability of smart contracts, hence that idea evolved into [Account Extensions](https://github.com/nearprotocol/neps/pull/346).
+
+## Future possibilities
+
+Supporting ZK proofs instead of just signatures can allow for an anonymous transactions, which pay fees to relayers in anonymous way.
+
+## Copyright
+[copyright]: #copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/neps/nep-0366.md
+++ b/neps/nep-0366.md
@@ -23,26 +23,26 @@ For example, apps that pay user for doing work (like NEARCrowd or Sweatcoin) or 
 
 ## Rationale and alternatives
 
-Proposed here design provides the easiest for users and developers way to onboard and pay for user transactions.
-There is no requirement on the user account, including user account may not even exist on chain and implicit account can be used.
+The proposed design here provides the easiest way for users and developers to onboard and to pay for user transactions.
+There are no requirements on the user account. The user account may not even exist on the chain and an implicit account can be used instead.
 
-An alternative is proxy contracts deployed on the user account.
-This design has severe limitations as it requires user to deploy such contract and additional costs for storage.
+An alternative is to a proxy contracts deployed on the user account.
+This design has severe limitations as it requires the user to deploy such contract and incur additional costs for storage.
 
 ## Specification
 
 The main flow of the meta transaction will be as follows:
- - User will sign `DelegateActionMessage` specifying set of actions that they need to be executed. It also includes specific relayer to ensure secure execution.
- - User sends signed `DelegateAction` data to the relayer
- - Relayer forms a `Transaction` with `receiver_id` equal to the user's account and `actions: [DelegateAction { ... }]`, and signs it with it's key. Note, that such transaction can contain other actions toward user's account (for example calling a function).
- - This transaction is processed normally, by creating a receipt with copy of the all the actions into the `Receipt`.
- - When processing `DelegateAction` a number of checks are done (see below), mainly `signature` matching user account's key.
- - When such `Receipt` with valid `DelegateAction` in actions arrives to the user's account it gets executed. The executed means creation of a new Receipt with `receiver_id: AccountId`, `actions: Action` matching `receiver_id` and `actions` inside `DelegateAction`. 
- - The new `Receipt` looks like normal receipt that would have been originating from user's account, with `predeccessor_id` equal to user's account.
+ - User signs a `DelegateActionMessage` specifying the set of actions that they need to be executed. It will also specify a relayer to ensure secure execution.
+ - User sends the signed `DelegateAction` data to the relayer.
+ - Relayer forms a `Transaction` with `receiver_id` equal to the user's account and `actions: [DelegateAction { ... }]` and signs it with it's key. Note that such transactions can contain other actions toward user's account (for example calling a function).
+ - This transaction is processed normally. A `Receipt` is created with a copy of the actions in the transaction.
+ - When processing a `DelegateAction`, a number of checks are done (see below), mainly a check to ensure that the `signature` matches the user account's key.
+ - When a `Receipt` with a valid `DelegateAction` in actions arrives at the user's account, it gets executed. Execution means creation of a new Receipt with `receiver_id: AccountId` and `actions: Action` matching `receiver_id` and `actions` in the `DelegateAction`.
+ - The new `Receipt` looks like a normal receipt that could have originated from the user's account, with `predeccessor_id` equal to user's account.
 
 ### DelegateAction
 
-Delegate action allows for an account to initiate a batch of actions on behalf of the receiving account, allowing to proxy actions. This is used in implementation of meta transactions.
+Delegate actions allows for an account to initiate a batch of actions on behalf of a receiving account, allowing proxy actions. This can be used to implement meta transactions.
 
 ```rust
 pub struct DelegateAction {
@@ -50,10 +50,10 @@ pub struct DelegateAction {
     receiver_id: AccountId,
     /// List of actions to be executed.
     actions: Vec<Action>,
- 
+
     /// Public key that is used to sign this delegated action.
     signer_pk: PublicKey,
-    /// Nonce is used to determine that the same delegate action is not sent twice by relayers and should match for given account's `signer_pk`. 
+    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `signer_pk`.
     /// After this action is processed it will increment.
     nonce: Nonce,
     /// Signature of the originating user signing `DelegateActionMessage` formed out of the data in the `DelegateAction`.
@@ -61,61 +61,62 @@ pub struct DelegateAction {
 }
 ```
 
- Supporting a batch of `actions` means `DelegateAction` can initiate a complex steps like creating a new account and transferring funds, deploying a contract and executing an initialization function.
+ Supporting batches of `actions` means `DelegateAction` can be used initiate a complex steps like creating new accounts, transferring funds, deploying contracts, and executing an initialization function all within the same transaction.
 
 ***Validation***:
-To ensure that `DelegateAction` is correct, on receival the verification of signature is done: `verify_signature(hash(message), signer_pk, signature)`.
+To ensure that a `DelegateAction` is correct, on receipt the following signature verification is performed: `verify_signature(hash(message), signer_pk, signature)`.
 
-The `message` is formed in the next format and must be signed by the user:
+A `message` is formed in the following format and it must be signed by the user:
 ```rust
 struct DelegateActionMessage {
-    /// If not None, should match the `predecessor_id` that have created `DelegateAction`.
+    /// If not None, then should match the `predecessor_id` that created the `DelegateAction`.
     sender_id: Option<AccountId>,
     /// Matching the given account_id.
     signer_id: AccountId,
-    /// Matching the `signer_pk` from `DelegateAction`.
+    /// Should match the `signer_pk` from the `DelegateAction`.
     public_key: PublicKey,
-    /// Nonce for the given `public_key` from `DelegateAction`.
+    /// Nonce for the given `public_key` from the `DelegateAction`.
     nonce: Nonce,
-    /// Matching the `receiver_id` from `DelegateAction`.
+    /// Should match the `receiver_id` from the `DelegateAction`.
     receiver_id: AccountId,
     /// Block hash to ensure validity.
-    /// Actions matching `actions` from `DelegateAction`.
+    block_hash: CryptoHash,
+    /// Should match `actions` from the `DelegateAction`.
     actions: Vec<Action>,
 }
 ```
 
 The next set of security concerns are addressed by this format:
- - If format matches `Transaction`, the relayer can just send it directly, not receiving payment.
- - Because set of actions can include pay back to the relayer (for example by paying in FT), the `sender_id` is added directly into the message to ensure that nobody else can send this message.
+ - If format matches `Transaction`, then the relayer can just send it directly, not receiving payment.
+ - Because the set of actions can include payment for the relayer (for example in FT), the `sender_id` is added directly into the message to ensure that nobody else can send this message.
  - `nonce` is included to ensure that this message can't be replayed again.
  - `public_key` and `signer_id` are needed to ensure the on the right account, work across rotating keys and fetch correct `nonce`.
 
-The permissions are verified based on kind `AccessKeyPermission` of `signer_pk`:
+The permissions are verified based on the variant of `signer_pk`:
  - `AccessKeyPermission::FullAccess`, all actions are allowed.
- - `AccessKeyPermission::FunctionCall`, only a single `FunctionCall` action is allowed in `actions`. 
+ - `AccessKeyPermission::FunctionCall`, only a single `FunctionCall` action is allowed in `actions`.
     - `DelegateAction.receiver_id` must match to the `account[public_key].receiver_id`
     - `DelegateAction.actions[0].method_name` must be in the `account[public_key].method_names`
 
 ***Outcomes***:
-- If `signature` matches receiver's accounts `signer_pk`, new receipt is created from this account with set of `ActionReceipt { receiver_id, action }` for each item in `actions`. 
+- If the `signature` matches the receiver's account's `signer_pk`, a new receipt is created from this account with a set of `ActionReceipt { receiver_id, action }` for each action in `actions`.
 
 #### Errors
 
 **Validation Error**
-- If `signer_pk` does not exist for the given account, the following error will be returned
+- If the `signer_pk` does not exist for the given account, the following error will be returned
 ```rust
-/// Signer key for delegate action is missing from given account
+/// Signer key for delegate action is missing from the given account
 DelegateActionSignerDoesNotExist
 ```
 
-- If `nonce` does not exist match `signer_pk` for  `receiver_id`, the following error will be returned
+- If the `nonce` does not exist match the `signer_pk` for the `receiver_id`, the the following error will be returned
 ```rust
 /// Nonce must be account[signer_pk].nonce + 1
 DelegateActionInvalidNonce
 ```
 
-- If `signature` does not match to the data and `signer_pk` of the given key, the following error will be returned
+- If the `signature` does not match the data and the `signer_pk` of the given key, then the following error will be returned
 ```rust
 /// Signature does not match the provided actions and given signer public key.
 DelegateActionInvalidSignature
@@ -126,21 +127,21 @@ See the [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateActi
 
 ## Security Implications
 
-Delegate actions do not override `signer_pk`, leaving that to the original signer that initiated transaction (eg relayer in meta transaction case). Although it is possible to override `signer_pk` in the context with one from `DelegateAction`, there is no clear value to do that.
+Delegate actions do not override `signer_pk`, leaving that to the original signer that initiated transaction (e.g. the relayer in the meta transaction case). Although it is possible to override the `signer_pk` in the context with one from the `DelegateAction`, there is no clear value in that.
 
-See ***Validation*** section in [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateAction) for security considerations around what user signs and validation of actions with different permissions.
+See the ***Validation*** section in [DelegateAction specification](specs/RuntimeSepc/Actions.md#DelegateAction) for security considerations around what the user signs and the validation of actions with different permissions.
 
 ## Drawbacks
 
-Increases complexity of the the NEAR's transactional model.
+Increases complexity of NEAR's transactional model.
 
-Meta transactions take an extra block to execute, as they first need to be included by the originating account, then routed to the delegate account and only after that to the real destination.
+Meta transactions take an extra block to execute, as they first need to be included by the originating account, then routed to the delegate account, and only after that to the real destination.
 
 Delegate actions are not programmable as they require having signatures. Original proposal contained a new `AccessKey` kind that would support programmable delegated actions. On the other hand, that would be limiting without programmability of smart contracts, hence that idea evolved into [Account Extensions](https://github.com/nearprotocol/neps/pull/346).
 
 ## Future possibilities
 
-Supporting ZK proofs instead of just signatures can allow for an anonymous transactions, which pay fees to relayers in anonymous way.
+Supporting ZK proofs instead of just signatures can allow for anonymous transactions, which pay fees to relayers anonymously.
 
 ## Copyright
 [copyright]: #copyright

--- a/neps/nep-0417.md
+++ b/neps/nep-0417.md
@@ -1,8 +1,8 @@
 ---
-NEP: 366
+NEP: 417
 Title: Meta Transactions
 Author: Illia Polosukhin <ilblackdragon@gmail.com>, Egor Uleyskiy (egor.ulieiskii@gmail.com), Alexander Fadeev (fadeevab.com@gmail.com)
-DiscussionsTo: https://github.com/nearprotocol/neps/pull/366
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/417
 Status: Draft
 Type: Protocol Track
 Category: Runtime

--- a/specs/RuntimeSpec/Receipts.md
+++ b/specs/RuntimeSpec/Receipts.md
@@ -1,6 +1,6 @@
 # Receipt
 
-All cross-contract (we assume that each account lives in its own shard) communication in Near happens through Receipts.
+All cross-contract (we assume that each account lives in it's own shard) communication in Near happens through Receipts.
 Receipts are stateful in a sense that they serve not only as messages between accounts but also can be stored in the account storage to await DataReceipts.
 
 Each receipt has a [`predecessor_id`](#predecessor_id) (who sent it) and [`receiver_id`](#receiver_id) the current account.
@@ -275,7 +275,7 @@ mainly two types of errors:
 ```rust
 /// The `receiver_id` of a Receipt is not valid.
 InvalidReceiverId { account_id: AccountId },
-``` 
+```
 error is returned.
 - some action is invalid. The errors returned here are the same as the validation errors mentioned in [actions](Actions.md).
 * Whether the account still has enough balance to pay for storage. If, for example, the execution of one function call


### PR DESCRIPTION
# Summary
This is a fork of [NEP-366](https://github.com/near/NEPs/pull/366). Main changes:
1. The implicit account case is described according to the comments [one](https://github.com/near/NEPs/pull/366#issuecomment-1278931208) and [two]( https://github.com/near/NEPs/pull/366#issuecomment-1279333217)
2. `DelegateAction` and `DelegateActionMessage` formats are changed.

*I will attach a diagram a little bit later.*