### PR TITLE
Proposal to allow attached_deposit in view contexts

### DIFF
--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -31,7 +31,7 @@ The alternative of returning some special value, say `u128::MAX`, is that it wou
 
 After the protocol version, the error inside `attached_deposit` will be skipped, and for all view calls, `0u128` will be set at the pointer passed in.
 
-## Reference Implementation (Required for Protocol Working Group proposals, optional for other categories)
+## Reference Implementation
 
 
 Currently, the implementation for `attached_deposit` is as follows:

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -78,6 +78,26 @@ This has a breaking change of the functionality of `attached_deposit` and affect
 - The Rust SDK, as well as other SDKs, can add the `attached_deposit() == 0` check by default to all methods for safety of use.
 - Potentially, other host functions can be allowed where reasonable values can be inferred. For example, `prepaid_gas`, `used_gas` could return 0.
 
+## Decision Context
+
+### 1.0.0 - Initial Version
+
+The initial version of NEP-418 was approved by Tools Working Group members on January 19, 2023 ([meeting recording](https://youtu.be/poVmblmc3L4)).
+
+#### Benefits
+
+- This will allow contract SDK frameworks to add the `attached_deposit == 0` assertion for every function on a contract by default.
+- This behavior matches the Solidity/Eth payable modifier and will ensure that funds aren't sent accidentally to a contract in more cases than currently possible.
+- Given that there is no way of checking if a function call is within view context to call `attached_deposit` conditionally, this NEP only changes a small surface of the API instead of introducing a new host function.
+
+#### Concerns
+
+| # | Concern | Resolution | Status |
+| - | - | - | - |
+| 1 | Proposal potentially triggers the protocol version change | It does not trigger the protocol version change. Current update could be considered a client-breaking change update. | Resolved |
+| 2 | The contract can assume that `attached_deposit` will panic in view contexts. | The possibility that this is done _and_ has some value connected with a view call result off-chain seems extremely unlikely. | Won't Fix |
+| 3 | Can we assume that in all view calls, the `attached_deposit` in the VMContext always zero? | Yes, there is no way to set `attached_deposit` in view calls context | Resolved |
+
 ## Copyright
 [copyright]: #copyright
 

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -39,15 +39,15 @@ The error inside `attached_deposit` for view calls will be removed, and for all 
 Currently, the implementation for `attached_deposit` is as follows:
 ```rust
 pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
-	self.gas_counter.pay_base(base)?;
+    self.gas_counter.pay_base(base)?;
 
-	if self.context.is_view() {
-		return Err(HostError::ProhibitedInView {
-			method_name: "attached_deposit".to_string(),
-		}
-		.into());
-	}
-	self.memory_set_u128(balance_ptr, self.context.attached_deposit)
+    if self.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "attached_deposit".to_string(),
+        }
+        .into());
+    }
+    self.memory_set_u128(balance_ptr, self.context.attached_deposit)
 }
 ```
 
@@ -55,9 +55,9 @@ Which would just remove the check for `is_view` to no longer throw an error:
 
 ```rust
 pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
-	self.gas_counter.pay_base(base)?;
+    self.gas_counter.pay_base(base)?;
 
-	self.memory_set_u128(balance_ptr, self.context.attached_deposit)
+    self.memory_set_u128(balance_ptr, self.context.attached_deposit)
 }
 ```
 

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -29,7 +29,7 @@ The alternative of returning some special value, say `u128::MAX`, is that it wou
 
 ## Specification
 
-After the protocol version, the error inside `attached_deposit` will be skipped, and for all view calls, `0u128` will be set at the pointer passed in.
+The error inside `attached_deposit` for view calls will be removed, and for all view calls, `0u128` will be set at the pointer passed in.
 
 ## Reference Implementation
 
@@ -49,18 +49,12 @@ pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
 }
 ```
 
-Which would just have to add the check:
+Which would just remove the check for `is_view` to no longer throw an error:
 
 ```rust
 pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
 	self.gas_counter.pay_base(base)?;
 
-	if self.context.protocol_version < VIEW_ATTACHED_DEPOSIT_PROTOCOL_VERSION && self.context.is_view() {
-		return Err(HostError::ProhibitedInView {
-			method_name: "attached_deposit".to_string(),
-		}
-		.into());
-	}
 	self.memory_set_u128(balance_ptr, self.context.attached_deposit)
 }
 ```

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -1,8 +1,8 @@
 ---
-NEP: TODO
+NEP: 0418
 Title: Remove attached_deposit view panic
 Author: Austin Abell <austin.abell@near.org>
-DiscussionsTo: https://github.com/nearprotocol/neps/pull/0000
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/418
 Status: Draft
 Type: Standards Track
 Category: Contract

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -63,17 +63,13 @@ pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
 
 This assumes that in all cases, `self.context.attached_deposit` is set to 0 in all cases. This can be asserted, or just to be safe, can check if `self.context.is_view()` and set `0u128` explicitly.
 
-## Security Implications (Optional)
+## Security Implications
 
 This won't have any implications outside of view calls, so this will not affect anything that is persisted on-chain. This only affects view calls. This can only have a negative side effect if a contract is under the assumption that `attached_deposit` will panic in view contexts. The possibility that this is done _and_ has some value connected with a view call result off-chain seems extremely unlikely.
 
-## Drawbacks (Optional)
+## Drawbacks
 
 This has a breaking change of the functionality of `attached_deposit` and affects the behavior of some function calls in view contexts if they use `attached_deposit` and no other prohibited host functions.
-
-## Unresolved Issues (Optional)
-
-- Is the assumption that in all view calls, the `attached_deposit` in the VMContext is zero correct?
 
 ## Future possibilities
 

--- a/neps/nep-0418.md
+++ b/neps/nep-0418.md
@@ -3,10 +3,12 @@ NEP: 0418
 Title: Remove attached_deposit view panic
 Author: Austin Abell <austin.abell@near.org>
 DiscussionsTo: https://github.com/nearprotocol/neps/pull/418
-Status: Draft
+Status: Approved
 Type: Standards Track
-Category: Contract
+Category: Tools
+Version: 1.0.0
 Created: 18-Oct-2022
+Updated: 27-Jan-2023
 ---
 
 ## Summary


### PR DESCRIPTION
A small UX improvement for contract developers. Markdown https://github.com/near/NEPs/blob/austin/view_attached_deposit/neps/nep-0418.md

Original discussion: https://near.zulipchat.com/#narrow/stream/295306-pagoda.2Fcontract-runtime/topic/attached_deposit.20view.20error