### PR TITLE
add contract_metadata_update event

### DIFF
--- a/neps/nep-0171.md
+++ b/neps/nep-0171.md
@@ -6,7 +6,9 @@ DiscussionsTo: https://github.com/near/NEPs/discussions/171
 Status: Final
 Type: Standards Track
 Category: Contract
+Version: 1.1.0
 Created: 03-Mar-2022
+Updated: 07-Mar-2023
 Requires: 297
 ---
 
@@ -216,21 +218,21 @@ function nft_on_transfer(
 
 ### Events
 
-NEAR and third-party applications need to track `mint`, `transfer`, `burn` events for all NFT-driven apps consistently.
+NEAR and third-party applications need to track `mint`, `transfer`, `burn`, and `contract_metadata_update` events for all NFT-driven apps consistently.
 This extension addresses that.
 
 Keep in mind that applications, including NEAR Wallet, could require implementing additional methods to display the NFTs correctly, such as [`nft_metadata`][Metadata] and [`nft_tokens_for_owner`][NFT Enumeration]).
 
-### Events Interface
+#### Events Interface
 
-Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, and `data` must be of one of the following relevant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[]`:
+Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.1.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, or `contract_metadata_update`, and `data` must be of one of the following relevant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[]`:
 
 ```ts
 interface NftEventLogData {
     standard: "nep171",
-    version: "1.0.0",
-    event: "nft_mint" | "nft_burn" | "nft_transfer",
-    data: NftMintLog[] | NftTransferLog[] | NftBurnLog[],
+    version: "1.1.0",
+    event: "nft_mint" | "nft_burn" | "nft_transfer" | "contract_metadata_update",
+    data: NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[],
 }
 ```
 
@@ -273,16 +275,23 @@ interface NftTransferLog {
     token_ids: string[],
     memo?: string
 }
+
+// An event log to capture contract metadata updates. Note that the updated contract metadata is not included in the log, as it could easily exceed the 16KB log size limit. Listeners can query `nft_metadata` to get the updated contract metadata.
+// Arguments
+// * `memo`: optional message
+interface NftContractMetadataUpdateLog {
+    memo?: string
+}
 ```
 
-## Examples
+#### Examples
 
 Single owner batch minting (pretty-formatted for readability purposes):
 
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_mint",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]}
@@ -295,7 +304,7 @@ Different owners batch minting:
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_mint",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]},
@@ -309,7 +318,7 @@ Different events (separate log entries):
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_burn",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]},
@@ -320,7 +329,7 @@ EVENT_JSON:{
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_transfer",
   "data": [
     {"old_owner_id": "user1.near", "new_owner_id": "user2.near", "token_ids": ["meme"], "memo": "have fun!"}
@@ -333,7 +342,7 @@ Authorized id:
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_burn",
   "data": [
     {"owner_id": "owner.near", "token_ids": ["goodbye", "aurevoir"], "authorized_id": "thirdparty.near"}
@@ -341,15 +350,27 @@ EVENT_JSON:{
 }
 ```
 
-## Further Event Methods
+Contract metadata update:
 
-Note that the example events covered above cover two different kinds of events:
-1. Events that are not specified in the NFT Standard (`nft_mint`, `nft_burn`)
-2. An event that is covered in the [NFT Core Standard](https://nomicon.io/Standards/NonFungibleToken/Core.html#nft-interface). (`nft_transfer`)
+```js
+EVENT_JSON:{
+  "standard": "nep171",
+  "version": "1.1.0",
+  "event": "contract_metadata_update",
+  "data": []
+}
+```
 
-This event standard also applies beyond the three events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](https://nomicon.io/Standards/NonFungibleToken/ApprovalManagement.html), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
+#### Events for Other NFT Methods
+
+Note that the example events above cover two different kinds of events:
+1. Events that do not have a dedicated trigger function in the NFT Standard (`nft_mint`, `nft_burn`, `contract_metadata_update`)
+2. An event that has a relevant trigger function [NFT Core Standard](https://nomicon.io/Standards/NonFungibleToken/Core.html#nft-interface) (`nft_transfer`)
+
+This event standard also applies beyond the events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](https://nomicon.io/Standards/NonFungibleToken/ApprovalManagement.html), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
  
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.
+
 
 ## Reference Implementation
 
@@ -357,12 +378,33 @@ Please feel free to open pull requests for extending the events standard detaile
 
 [NFT Implementation](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/non_fungible_token/core/core_impl.rs)
 
-## Errata
+
+## Changelog
+
+### 1.0.0 - Initial version
+
+This NEP had several pre-1.0.0 iterations that led to the following errata updates to this NEP:
 
 * **2022-02-03**: updated `Token` struct field names. `id` was changed to `token_id`. This is to be consistent with current implementations of the standard and the rust SDK docs.
-
 * **2021-12-20**: updated `nft_resolve_transfer` argument `approved_account_ids` to be type `null|Record<string, number>` instead of `null|string[]`. This gives contracts a way to restore the original approved accounts and their approval IDs. More information can be found in [this](https://github.com/near/NEPs/issues/301) discussion.
 * **2021-07-16**: updated `nft_transfer_call` argument `approval_id` to be type `number|null` instead of `string|null`. As stated, approval IDs are not expected to exceed the JSON limit of 2^53.
+
+### 1.1.0 - Add `contract_metadata_update` Event
+
+The extension NEP-0423 that added Contract Metadata to this NEP-0171 was approved by Contract Standards Working Group members (@frol, @abacabadabacaba, @mfornet) on January 13, 2023 ([meeting recording](https://youtu.be/pBLN9UyE6AA)).
+
+#### Benefits
+
+* This new event type will help indexers to invalidate their cached values reliably and efficiently
+* This NEP extension only introduces an additional event type, so there is no breaking change to the original NEP
+
+#### Concerns
+
+| # | Concern | Resolution | Status |
+| - | - | - | - |
+| 1 | Old NFT contracts do not emit JSON Events at all; more recent NFT contracts will only emit mint/burn/transfer events, so when it comes to legacy contracts support, we won’t benefit from this new event type and only further fragment the implementations | Legacy contracts usage will die out eventually and new contracts will support new features in a non-breaking way | Resolved |
+| 2 | There is a need to have a similar event type for individual NFT updates | It is outside of the scope of this NEP extension. Feel free to create a follow-up proposal | Resolved |
+
 
 ## Copyright
 [copyright]: #copyright

--- a/specs/Standards/Tokens/NonFungibleToken/Event.md
+++ b/specs/Standards/Tokens/NonFungibleToken/Event.md
@@ -1,11 +1,10 @@
 # Events
 
-Version `1.0.0`
+Version `1.1.0`
 
 ## Summary
 
-Standard interface for NFT contract actions.
-Extension of [NEP-297](../../EventsFormat.md)
+Standard interface for NFT contract actions based on [NEP-297](../../EventsFormat.md).
 
 ## Motivation
 
@@ -16,7 +15,7 @@ Keep in mind that applications, including NEAR Wallet, could require implementin
 
 ## Interface
 
-Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, `contract_metadata_update`, and `data` must be of one of the following relavant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[]`:
+Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.1.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, `contract_metadata_update`, and `data` must be of one of the following relavant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[]`:
 
 ```ts
 interface NftEventLogData {
@@ -152,12 +151,12 @@ EVENT_JSON:{
 }
 ```
 
-## Further methods
+## Events for Other NFT Methods
 
-Note that the example events covered above cover two different kinds of events:
-1. Events that are not specified in the NFT Standard (`nft_mint`, `nft_burn`, `contract_metadata_update`)
-2. An event that is covered in the [NFT Core Standard](Core.md). (`nft_transfer`)
+Note that the example events above cover two different kinds of events:
+1. Events that do not have a dedicated trigger function in the NFT Standard (`nft_mint`, `nft_burn`, `contract_metadata_update`)
+2. An event that has a relevant trigger function [NFT Core Standard](Core.md#nft-interface) (`nft_transfer`)
 
-This event standard also applies beyond the four events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](ApprovalManagement.md), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
+This event standard also applies beyond the events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](ApprovalManagement.md), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
  
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.

--- a/specs/Standards/Tokens/NonFungibleToken/Event.md
+++ b/specs/Standards/Tokens/NonFungibleToken/Event.md
@@ -21,7 +21,7 @@ Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard versi
 ```ts
 interface NftEventLogData {
     standard: "nep171",
-    version: "1.0.0",
+    version: "1.1.0",
     event: "nft_mint" | "nft_burn" | "nft_transfer",
     data: NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[],
 }
@@ -67,13 +67,11 @@ interface NftTransferLog {
     memo?: string
 }
 
-// An event log to capture contract metdata updates
+// An event log to capture contract metadata updates. Note that the updated contract metadata is not included in the log, as it could easily exceed the 16KB log size limit. Listeners can query `nft_metadata` to get the updated contract metadata.
 // Arguments
-// * `owner_id`: "account.near"
-// * `token_ids`: ["1", "abc"]
 // * `memo`: optional message
-interface NftMintLog {
-    metadata: NFTContractMetadata
+interface NftContractMetadataUpdateLog {
+    memo?: string
 }
 ```
 
@@ -84,7 +82,7 @@ Single owner batch minting (pretty-formatted for readability purposes):
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_mint",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]}
@@ -97,7 +95,7 @@ Different owners batch minting:
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_mint",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]},
@@ -111,7 +109,7 @@ Different events (separate log entries):
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_burn",
   "data": [
     {"owner_id": "foundation.near", "token_ids": ["aurora", "proximitylabs"]},
@@ -122,7 +120,7 @@ EVENT_JSON:{
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_transfer",
   "data": [
     {"old_owner_id": "user1.near", "new_owner_id": "user2.near", "token_ids": ["meme"], "memo": "have fun!"}
@@ -135,7 +133,7 @@ Authorized id:
 ```js
 EVENT_JSON:{
   "standard": "nep171",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "event": "nft_burn",
   "data": [
     {"owner_id": "owner.near", "token_ids": ["goodbye", "aurevoir"], "authorized_id": "thirdparty.near"}
@@ -150,9 +148,7 @@ EVENT_JSON:{
   "standard": "nep171",
   "version": "1.1.0",
   "event": "contract_metadata_update",
-  "data": [
-    { "metadata": { "base_uri": "..." } }
-  ]
+  "data": []
 }
 ```
 

--- a/specs/Standards/Tokens/NonFungibleToken/Event.md
+++ b/specs/Standards/Tokens/NonFungibleToken/Event.md
@@ -9,21 +9,21 @@ Extension of [NEP-297](../../EventsFormat.md)
 
 ## Motivation
 
-NEAR and third-party applications need to track `mint`, `transfer`, `burn` events for all NFT-driven apps consistently.
+NEAR and third-party applications need to track `mint`, `transfer`, `burn` and `contract_metadata_update` events for all NFT-driven apps consistently.
 This extension addresses that.
 
 Keep in mind that applications, including NEAR Wallet, could require implementing additional methods to display the NFTs correctly, such as [`nft_metadata`](Metadata.md) and [`nft_tokens_for_owner`](Enumeration.md).
 
 ## Interface
 
-Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, and `data` must be of one of the following relavant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[]`:
+Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard version set to `"1.0.0"`, `event` value is one of `nft_mint`, `nft_burn`, `nft_transfer`, `contract_metadata_update`, and `data` must be of one of the following relavant types: `NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[]`:
 
 ```ts
 interface NftEventLogData {
     standard: "nep171",
     version: "1.0.0",
     event: "nft_mint" | "nft_burn" | "nft_transfer",
-    data: NftMintLog[] | NftTransferLog[] | NftBurnLog[],
+    data: NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[],
 }
 ```
 
@@ -65,6 +65,15 @@ interface NftTransferLog {
     new_owner_id: string,
     token_ids: string[],
     memo?: string
+}
+
+// An event log to capture contract metdata updates
+// Arguments
+// * `owner_id`: "account.near"
+// * `token_ids`: ["1", "abc"]
+// * `memo`: optional message
+interface NftMintLog {
+    metadata: NFTContractMetadata
 }
 ```
 
@@ -134,12 +143,25 @@ EVENT_JSON:{
 }
 ```
 
+Contract metadata update:
+
+```js
+EVENT_JSON:{
+  "standard": "nep171",
+  "version": "1.1.0",
+  "event": "contract_metadata_update",
+  "data": [
+    { "metadata": { "base_uri": "..." } }
+  ]
+}
+```
+
 ## Further methods
 
 Note that the example events covered above cover two different kinds of events:
-1. Events that are not specified in the NFT Standard (`nft_mint`, `nft_burn`)
+1. Events that are not specified in the NFT Standard (`nft_mint`, `nft_burn`, `contract_metadata_update`)
 2. An event that is covered in the [NFT Core Standard](Core.md). (`nft_transfer`)
 
-This event standard also applies beyond the three events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](ApprovalManagement.md), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
+This event standard also applies beyond the four events highlighted here, where future events follow the same convention of as the second type. For instance, if an NFT contract uses the [approval management standard](ApprovalManagement.md), it may emit an event for `nft_approve` if that's deemed as important by the developer community.
  
 Please feel free to open pull requests for extending the events standard detailed here as needs arise.

--- a/specs/Standards/Tokens/NonFungibleToken/Event.md
+++ b/specs/Standards/Tokens/NonFungibleToken/Event.md
@@ -22,7 +22,7 @@ Non-Fungible Token Events MUST have `standard` set to `"nep171"`, standard versi
 interface NftEventLogData {
     standard: "nep171",
     version: "1.1.0",
-    event: "nft_mint" | "nft_burn" | "nft_transfer",
+    event: "nft_mint" | "nft_burn" | "nft_transfer" | "contract_metadata_update",
     data: NftMintLog[] | NftTransferLog[] | NftBurnLog[] | NftContractMetadataUpdateLog[],
 }
 ```


### PR DESCRIPTION
Added `contract_metadata_update` event to `Standards -> Tokens -> NonFungibleToken` as per the following discussion: https://gov.near.org/t/extending-nep-171-events-standard-to-include-contract-metadata-update-events/30384

Implementation of this new event enables 3rd party applications to listen for updates to NFT contract metadata, e.g. a new dedicated IPFS gateway (`base_uri`) and provide a consistent and higher quality experience for their users.