### PR TITLE
Update nep-0001.md

### DIFF
--- a/neps/nep-0001.md
+++ b/neps/nep-0001.md
@@ -24,7 +24,7 @@ The purpose of the NEP process is to ensure seamless protocol upgrades and to em
 
 The working groups are responsible for coordinating the public review of NEPs, gauging the viability and community support, and overseeing decisions. Each group will focus on various ecosystem needs, such as the protocol, standards, and tools.
 
-Pagoda has selected a few leading subject matter experts to help bootstrap the first two groups: Protocols and Contract Standards. Putting these groups into practice will require flexibility. The goal is to iterate and eventually introduce more groups and broader participation. Visit [https://near.org/working-groups](https://near.org/working-groups) to learn more about these groups, their members, and the upcoming meetings.
+Pagoda has selected a few leading subject matter experts to help bootstrap the first two groups: Protocols and Contract Standards. Putting these groups into practice will require flexibility. The goal is to iterate and eventually introduce more groups and broader participation. Visit [https://near.org/developer-governance](https://near.org/developer-governance) to learn more about these groups, their members, and the upcoming meetings.
 
 ## Audience
 The typical primary audience for NEPs are the core developers of the NEAR reference implementations and decentralized applications developers
@@ -66,16 +66,33 @@ The NEP workflow is:
   - The title accurately describes the content.
   - The language (spelling, grammar, sentence structure, etc.) and code style are correct and conformant.
 - If the NEP is not ready for approval, the moderators will send it back to the author for revision, with specific instructions in the pull request. The review by the moderators is expected to finish within one week.
-- Once the moderators agree that the PR is ready for review, the moderators notify the approvers (working groups) to assign a team of at least two reviewers (subject matter experts) to review the NEP. The reviewers will review the technical details of the proposal and assess its merits. They may ask clarification questions, request changes, or reject the proposal. The review by the reviewers is expected to finish within one week. The author of the proposal is free to revise the proposal and re-request reviews from reviewers.
-- If a proposal is in the review stage for more than two months, it is automatically rejected. To re-open the proposal, the author must start over with the NEP process again.
-- Once the reviewers agree that the proposal is close to a decision, they will have a final two week review period to add their comments, and then ask the author to present the NEP to the working group in a meeting, where it can enter the final voting stage. If the moderators agree that the NEP is overall beneficial for the NEAR ecosystem and vote to approve it, then the proposal is considered accepted.
+- Once the moderators agree that the PR is ready for review, the moderators will notify the approvers (working group members) to assign a team of at least two reviewers (subject matter experts) to review the NEP. The reviewers will review the technical details of the proposal and assess its merits. They may ask clarification questions, request changes, or reject the proposal. If the assigned reviewers feel that they do not have the relevant expertise to fully review the NEP, they can request the working group to re-assign subject matter experts for the NEP.
+- The review by the reviewers is expected to finish within one week. After completing the review, the reviewer must add an explicit comment to indicate the next step and tag the appropriate member:
+  - To request revisions from the author: "As the assigned Reviewer, I request from the author @author-username to address [provide concerns or suggestions]."
+  - To move to the next stage: "As the assigned Reviewer, I do not have any feedback for the author. I recommend moving this NEP forward and for the working group to [accept or reject] it based on [provide reasoning, including a sense of importance or urgency of this NEP]."
+- The author of the proposal is free to revise the proposal and re-request reviews from reviewers. If a proposal is in the review stage for more than two months, the moderator will automatically reject it. To re-open the proposal, the author must start over with the NEP process again.
+- Once the two reviewers agree that the proposal is close to the voting stage, the moderators will assign the approvers (working group) to review the NEP. The approvers will review the proposal and add their voting indication.
+- The final review period by the approvers is expected to finish within one week. After completing the review, the approvers must add an explicit comment with their voting indication:
+  - To reject: "As a working group member, I lean towards rejecting this proposal based on [provide reasoning]."
+  - To approve: "As a working group member, I lean towards approving this NEP based on [provide reasoning]."
+- Once all the approvers add their voting indication, the moderator will review the voting indication for a 2/3 majority vote:
+  - If the votes lean toward rejection: The moderator will summarize the feedback and close the NEP.
+  - If the votes lean toward approval: The moderator will schedule a public call (see [NEP Communication](#nep-communication)) for the author to present the NEP and for the working group members to formalize the voting decision. If the working group members agree that the NEP is overall beneficial for the NEAR ecosystem and vote to approve it, then the proposal is considered accepted. After the call, the moderator will summarize the decision on the NEP.
+
+### NEP Communication
+
+NEP discussions should happen asynchronously within the NEP’s public thread. 
+
+However, if a discussion becomes circular and could benefit from a synchronous conversation, any participants on a given NEP can suggest for the moderator to schedule an ad hoc meeting. For example, if a reviewer and author have multiple rounds of comments, they may request a call. The moderator can help coordinate the call and post the registration link on the NEP. The person who requested the call should designate a note taker to post a summary on the NEP after the call. 
+
+When a NEP gets to the final voting stage, the moderator will schedule a public working group meeting to discuss the NEP with the author and formalize the decision. The moderator will first coordinate a time with the author and working group members, and then post the meeting time and registration link on the NEP at least one week in advance. 
 
 ### NEP Maintenance
 In general, NEPs are no longer modified after they have reached the Final state.
 
 ## NEP Life Cycle
 
-![NEP Process](https://user-images.githubusercontent.com/110252255/184407496-e96b0a96-af43-4694-90ed-58d8bb463958.png)
+![NEP Process](https://user-images.githubusercontent.com/110252255/201413632-f72743d6-593e-4747-9409-f56bc38de17b.png)
 
 A given NEP can have one of the following states:
 
@@ -119,12 +136,11 @@ The NEP process has various roles and responsibilities.
 
 - Gives feedback on proposals
 - Assesses technical feasibility of proposals
-- Has rejecting voting power
 - Does not have the ability to approve proposal
 
 ![Approver](https://user-images.githubusercontent.com/110252255/181816752-521dd147-f56f-4c5c-84de-567b109f21d6.png)
 **Approver** (Community Working Groups)<br />
-*Appointed by Pagoda in the boostraphing phase*
+*Appointed by Pagoda in the bootstrapping phase*
 
 - Assigns reviewers to proposals
 - Attends working group meetings to review proposals
@@ -193,7 +209,7 @@ Images, diagrams and auxiliary files should be included in a subdirectory of the
 ## Transferring NEP Ownership
 It occasionally becomes necessary to transfer ownership of NEPs to a new author. In general, it is preferable to retain the original author as a co-author of the transferred NEP, but that is up to the original author. A good reason to transfer ownership is because the original author no longer has the time or interest in updating it or following through with the NEP process. A bad reason to transfer ownership is because the author does not agree with the direction of the NEP. One aim of the NEP process is to try to build consensus around a NEP, but if that is not possible, an author can submit a competing NEP.
 
-If you are interested in assuming ownership of a NEP, you can also do this via pull request. Fork the NEP repository, make your ownership modification, and submit a pull request. You should mention both the original author and @near/nep-editors in a comment on the pull request.
+If you are interested in assuming ownership of a NEP, you can also do this via pull request. Fork the NEP repository, make your ownership modification, and submit a pull request. In the PR description, tag the original author and provide a summary of the work that was previously done. Also clearly state the intent of the fork and the relationship of the new PR to the old one. For example: "Forked to address the remaining review comments in NEP # since the original author does not have time to address them."
 
 ## Style Guide
 


### PR DESCRIPTION
We updated the following sections based on feedback we got from processing recent NEPS:
- Clarified the NEP workflow and lifecycle diagram with specific actions that created bottlenecks
- Clarified the responsibilities of the Reviewer (Subject Matter Expert)
- Clarified how to modify a NEP when it is still in the review phase
- Added a new NEP communication section