### PR TITLE
NEP-431 FT allowance

### DIFF
--- a/neps/nep-0000.md
+++ b/neps/nep-0000.md
@@ -1,7 +1,7 @@
 ---
-NEP: 0365
+NEP: 0000
 Title: FT Standards Allowance
-Author: Firat Sertgoz <firat@near.org>, Austin Abell <austin.abell@near.org
+Author: Firat Sertgoz <firat@near.org>, Austin Abell <austin.abell@near.org>
 DiscussionsTo: https://github.com/nearprotocol/neps/pull/0000
 Status: Draft
 Type: Standards Track
@@ -11,24 +11,24 @@ Created: 09-Nov-2022
 
 ## Summary
 
-An extension to FT standard that allows users to give allowance to other accounts or keys for transfering [NEP-141] tokens on behalf of them. 
+An extension to the FT standard that allows users to give allowance to other accounts or keys for transferring [NEP-141] tokens on their behalf. 
 
 ## Motivation
-People familiar with [NEP-141] might have seen the prior art [NEP-21] which talks about a similar approach to Ethereum [ERC-20] standard, where a third party account is given an allowance to withdraw on behalf of an account. The discussion on NEP-21 proposal was specifically for `ft_transfer_call`, where the proposal was weighed against `async` paradigm and was rejected. 
+People familiar with [NEP-141] might have seen the prior art [NEP-21], which talks about a similar approach to the Ethereum [ERC-20] standard, where a third-party account is given an allowance to withdraw on behalf of an account. The discussion on the NEP-21 proposal was specifically for `ft_transfer_call`, where the proposal was weighed against `async` paradigm and was rejected. 
 
 The current motivation is to delegate to a third party the ability to withdraw funds and allow them to do that fast.
 
-This opens the opportunity for token transfer gas costs to be payed by the spender. Potentially, the balance owner would only have to pay for the gas cost of the `ft_approve` function. After that point on, `ft_transfer_from` calls could be payed by the spender. One small note to consider is that [NEP-366] is solving the transaction costs being payed by a relayer. However, in case of a `ft_transfer` call, the `final transaction execution` would take at least 3 blocks (sender account -> relayer -> ft contract). This might be too slow for certain applications. 
+This allows token transfer gas costs to be paid by the spender. Potentially, the balance owner would only have to pay for the gas cost of the `ft_approve` function. After that point on, `ft_transfer_from` calls could be paid by the spender. One small note to consider is that [NEP-366] is solving the transaction costs being paid by a relayer. However, in case of a `ft_transfer` call, the `final transaction execution` would take at least 3 blocks (sender account -> relayer -> ft contract). This might be too slow for certain applications. 
 
-Another use-case is a subscription model. A balancer owner can approve a certain allowance for the spender to withdraw funds on a hourly/monthly/yearly basis. In this case, after initial allowance, balance owner doesn't need to intitate transfers and can take a passive role while the spender could withdraw funds on the allowance. The balance owner can always `cancel` their subscription by removing the allowance. 
+Another use case is a subscription model. A balancer owner can approve a certain allowance for the spender to withdraw funds on an hourly/monthly/yearly basis. In this case, after the initial allowance, the balance owner doesn't need to initiate transfers and can take a passive role, while the spender could withdraw funds on the allowance. The balance owner can always `cancel` their subscription by removing the allowance. 
 
 
 ## Rationale and alternatives
-Currently there is no way of allowing a third party to withdraw funds based on an allowance. `ft_transfer` transactions have to be initiated by the balance owner. This limits certain use-cases like the one above.
+Currently, there is no way of allowing a third party to withdraw funds based on an allowance. `ft_transfer` transactions have to be initiated by the balance owner. This limits certain use cases like the one above.
 
 #### Why is this design the best in the space of possible designs?
 
-This design follows a similar pattern to [ERC-20] approval/allowance pattern that has been widely accepted in the industry and battle-tested. Shortcomings of the pattern is well-known and necessary changes to overcome the shortcomings is explained in this design. (See `ft_approve` function for atomicity)
+This design follows a similar pattern to [ERC-20] approval/allowance pattern that has been widely accepted in the industry and battle-tested. Shortcomings of the pattern are well-known and necessary changes to overcome the shortcomings are explained in this design. (See `ft_approve` function for atomicity)
 
 
 #### What is the impact of not doing this?
@@ -48,7 +48,7 @@ We should be able to do the following:
 
 There are a few concepts in the scenario above that needs explaining.
 
-- **Spender**: An account or a access key that has approval to withdraw funds from another account
+- **Spender**: An account or an access key that has approval to withdraw funds from another account
 -  **Balance owner account**: An account that is the subject of the withdrawal. 
 -  **Allowance**: The amount of tokens for the spender account that the spender can use on behalf of the balance account owner.
 -  **Approval**: A mapping of Account Owner and Spender to allowance.
@@ -60,7 +60,7 @@ There are a few concepts in the scenario above that needs explaining.
 
 - All amounts, balances and allowance are limited by U128 (max value 2**128 - 1).
 - Having `0` as amount is not permitted, unlike ERC20 specification.
-- There is a need to explicity mention `ft_transfer_from_account` and `ft_transfer_from_key` due to an edge case where giving a function call access key to call `ft_transfer_from` would allow this access key to use any of the funds approved for the contract account id itself. Thus, `ft_transfer_from` is divided into two different functions.
+- There is a need to explicitly mention `ft_transfer_from_account` and `ft_transfer_from_key` due to an edge case where giving a function call access key to call `ft_transfer_from` would allow this access key to use any of the funds approved for the contract account id itself. Thus, `ft_transfer_from` is divided into two different functions.
 
 ```rs
     // ---- Approval standard -----
@@ -70,8 +70,6 @@ There are a few concepts in the scenario above that needs explaining.
         Account(AccountId),
         Key(PublicKey),
     }
-
-
 
     /// Approve the passed address to spend the specified amount of tokens on behalf of
     /// `env::predecessor_account_id`.
@@ -158,9 +156,33 @@ There are a few concepts in the scenario above that needs explaining.
     
     ///Emitted when the allowance of a spender for an owner is set by a call to approve. value is the new allowance.
     Approval(owner: AccountId, spender: AccountId, value: U128)
-    
 ```
 
+### Serialization formats
+
+The `AccountOrKey` enum serialization will look like:
+
+```json
+{"account":"<Account ID>"}
+```
+
+OR
+
+```json
+{"key":"<Public key>"}
+```
+
+And the event serialization will look like:
+
+<!-- TODO update NEP with number on PR open -->
+```json
+{
+    "standard":"nep0000",
+    "version":"1.0.0",
+    "event":"ft_allowance",
+    "data":{"owner":"<Account ID>","spender":"<Account ID>","value":"<amount>"}
+}
+```
 
 ## Security Implications
 
@@ -170,7 +192,7 @@ The possibility of giving unlimited allowance to an account or a key would allow
 
 ## Drawbacks 
 
-Even though this is an extension to [NEP-141], it complicates the working model of the async nature of NEAR. People might compare this model with [ERC-20] allowance model and the way it is being used.
+Even though this is an extension to [NEP-141], it complicates the working model because of the async nature of NEAR and the choice to support approvals for access keys. People might compare this model with [ERC-20] allowance model and the way it is being used.
 
 The implementation should clearly state that this is not a replacement of [NEP-141] but an extension for a different use-case.
 

--- a/neps/nep-0365.md
+++ b/neps/nep-0365.md
@@ -20,6 +20,8 @@ The current motivation is to delegate to a third party the ability to withdraw f
 
 A valid use-case for using such a flow is when an application needs to have transaction finality in one block. Given the sharded design of NEAR Protocol, `ft_transfer` calls, unless `sender_is_receiver`, would take at least 2 blocks to generate execution outcomes for all of it's receipts except for the refund. However, if an account gives approval of withdrawal of [NEP-141] tokens to the FT contract account or a key that belongs to the FT contract account, since `sender_is_receiver`, the `ft_transfer_from` transaction finality would be achieved in one block. This opens up the opportunity to have low-latency transactions on [NEP-141] contracts.
 
+Another use-case is a subscription model. A balancer owner can approve a certain allowance for the spender to withdraw funds on a hourly/monthly/yearly basis. In this case, after initial allowance, balance owner doesn't need to intitate transfers and can take a passive role while the spender could withdraw funds on the allowance. The balance owner can always `cancel` their subscription by removing the allowance. 
+
 
 ## Rationale and alternatives
 Currently there is no way of allowing a third party to withdraw funds based on an allowance. `ft_transfer` transactions have to be initiated by the balance owner. This limits certain use-cases like the one above.

--- a/neps/nep-0365.md
+++ b/neps/nep-0365.md
@@ -1,0 +1,197 @@
+---
+NEP: 0365
+Title: FT Standards Allowance
+Author: Firat Sertgoz <firat@near.org>, Austin Abell <austin.abell@near.org
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/0000
+Status: Draft
+Type: Standards Track
+Category: Contract
+Created: 09-Nov-2022
+---
+
+## Summary
+
+An extension to FT standard that allows users to give allowance to other accounts or keys for transfering [NEP-141] tokens on behalf of them. 
+
+## Motivation
+People familiar with [NEP-141] might have seen the prior art [NEP-21] which talks about a similar approach to Ethereum [ERC-20] standard, where a third party account is given an allowance to withdraw on behalf of an account. The discussion on NEP-21 proposal was specifically for `ft_transfer_call`, where the proposal was weighed against `async` paradigm and was rejected. 
+
+The current motivation is to delegate to a third party the ability to withdraw funds and allow them to do that fast.
+
+A valid use-case for using such a flow is when an application needs to have transaction finality in one block. Given the sharded design of NEAR Protocol, `ft_transfer` calls, unless `sender_is_receiver`, would take at least 2 blocks to generate execution outcomes for all of it's receipts except for the refund. However, if an account gives approval of withdrawal of [NEP-141] tokens to the FT contract account or a key that belongs to the FT contract account, since `sender_is_receiver`, the `ft_transfer_from` transaction finality would be achieved in one block. This opens up the opportunity to have low-latency transactions on [NEP-141] contracts.
+
+
+## Rationale and alternatives
+Currently there is no way of allowing a third party to withdraw funds based on an allowance. `ft_transfer` transactions have to be initiated by the balance owner. This limits certain use-cases like the one above.
+
+
+ 
+
+#### Why is this design the best in the space of possible designs?
+
+This design follows a similar pattern to [ERC-20] approval/allowance pattern that has been widely accepted in the industry and battle-tested. Shortcomings of the pattern is well-known and necessary changes to overcome the shortcomings is explained in this design. (See `ft_approve` function for atomicity)
+
+
+#### What other designs have been considered and what is the rationale for not choosing them?
+
+[Not sure what to put here]
+
+#### What is the impact of not doing this?
+
+Not providing a standard on third-party allowances for transfers could lead to different implementations on smart-contracts that could lead to security vulnerabilities. 
+
+
+## Specification
+
+### Guide-level explanation
+
+We should be able to do the following:
+- Approve a spender to withdraw funds on behalf of the balance owner account
+- Allow spender to either be an Account or an Access Key
+- Allow spender to withdraw funds
+- Allow an account to get their approvals
+
+There are a few concepts in the scenario above that needs explaining.
+
+- **Spender**: An account or a access key that has approval to withdraw funds from another account
+-  **Balance owner account**: An account that is the subject of the withdrawal. 
+-  **Allowance**: The amount of tokens for the spender account that the spender can use on behalf of the balance account owner.
+-  **Approval**: A mapping of Account Owner and Spender to allowance.
+
+
+## Reference Implementation
+
+**NOTES**
+
+- All amounts, balances and allowance are limited by U128 (max value 2**128 - 1).
+- Having `0` as amount is not permitted, unlike ERC20 specification.
+- There is a need to explicity mention `ft_transfer_from_account` and `ft_transfer_from_key` due to an edge case where giving a function call access key to call `ft_transfer_from` would allow this access key to use any of the funds approved for the contract account id itself. Thus, `ft_transfer_from` is divided into two different functions.
+
+```rs
+    // ---- Approval standard -----
+
+    /// Enum that is used to identify the Spender
+    pub enum AccountOrKey {
+        Account(AccountId),
+        Key(PublicKey),
+    }
+
+
+
+    /// Approve the passed address to spend the specified amount of tokens on behalf of
+    /// `env::predecessor_account_id`.
+    ///
+    /// Arguments:
+    /// * `spender` The address which will spend the funds.
+    /// * `current_value` The amount of tokens currently allowed. This is used to ensure atomicity.
+    /// * `value` The amount of tokens to be spent.
+    pub fn ft_approve(&mut self, spender: AccountOrKey, current_value: U128, value: U128)
+
+    /// Transfer funds from a `from` to `to` specifically for `account` as spender
+    /// * `to` The address which the transfer will be made from
+    /// * `from` The address which the transfer will be made to
+    /// * `amount' The amount of tokens to be transferred
+    /// * `memo` Optional message to be sent with the transfer
+    pub fn ft_transfer_from_account(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        amount: U128,
+        memo: Option<String>,
+    )
+     /// Transfer funds from a `from` to `to` specifically for `key` as spender
+    /// * `from` The address which the transfer will be made from
+    /// * `to` The address which the transfer will be made to
+    /// * `amount' The amount of tokens to be transferred
+    /// * `memo` Optional message to be sent with the transfer
+    pub fn ft_transfer_from_key(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        amount: U128,
+        memo: Option<String>,
+    )
+    /// Transfer funds from a `from` to `to` adddress for accounts. This method is specifically for cross-contract calls and returns a promise
+    /// * `from' The address which the transfer will be made from
+    /// * `to` The address which the transfer will be made to
+    /// * `amount' The amount of tokens to be transferred
+    /// * `memo` Optional message to be sent with the transfer
+    /// * 'msg' message to be sent to the receiving contract
+    pub fn ft_transfer_call_from_account(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        amount: U128,
+        memo: Option<String>,
+        msg: String,
+    ) -> PromiseOrValue<U128>
+    /// Transfer funds from a `from` to `to` adddress for keys. This method is specifically for cross-contract calls and returns a promise
+    /// * `from' The address which the transfer will be made from
+    /// * `to` The address which the transfer will be made to
+    /// * `amount' The amount of tokens to be transferred
+    /// * `memo` Optional message to be sent with the transfer
+    /// * 'msg' message to be sent to the receiving contract
+    pub fn ft_transfer_call_from_key(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        amount: U128,
+        memo: Option<String>,
+        msg: String,
+    ) -> PromiseOrValue<U128>
+    
+    /// Callback function for ft_transfer_call_from, handles the remaining allowance. Increases the current allowance by the unused amount. 
+    pub fn ft_resolve_transfer_from(
+        &mut self,
+        spender: AccountOrKey,
+        sender_id: AccountId,
+        receiver_id: AccountId,
+        amount: U128,
+    ) -> U128
+
+    /****************/
+    /* VIEW METHODS */
+    /****************/
+
+    /// Returns the allowance amount for a spender
+    /// * 'owner' Owner of the allowance
+    /// * 'spender' Spender of the allowance can be a key or an account
+    pub fn ft_allowance(&self, owner: AccountId, spender: AccountOrKey) -> 
+    /****************/
+    /*     EVENTS   */
+    /****************/
+    
+    ///Emitted when the allowance of a spender for an owner is set by a call to approve. value is the new allowance.
+    Approval(owner: AccountId, spender: AccountId, value: U128)
+    
+```
+
+
+## Security Implications
+
+The possibility of giving unlimited allowance to an account or a key would allow malicious key holder or account owner to drain the whole account. 
+
+
+
+## Drawbacks 
+
+Even though this is an extension to [NEP-141], it complicates the working model of the async nature of NEAR. People might compare this model with [ERC-20] allowance model and the way it is being used.
+
+The implementation should clearly state that this is not a replacement of [NEP-141] but an extension for a different use-case.
+
+
+
+
+## Future possibilities
+
+- Adding deposit on key allowance
+- Deleting unused Allowance to avoid state bloat
+
+## Copyright
+[copyright]: #copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC-20]: https://eips.ethereum.org/EIPS/eip-20
+[NEP-141]: https://github.com/near/NEPs/blob/master/neps/nep-0141.md
+[NEP-21]: https://github.com/near/NEPs/pull/21

--- a/neps/nep-0365.md
+++ b/neps/nep-0365.md
@@ -18,9 +18,7 @@ People familiar with [NEP-141] might have seen the prior art [NEP-21] which talk
 
 The current motivation is to delegate to a third party the ability to withdraw funds and allow them to do that fast.
 
-A valid use-case for using such a flow is when an application needs to have transaction finality in one block. Given the sharded design of NEAR Protocol, `ft_transfer` calls, unless `sender_is_receiver`, would take at least 2 blocks to generate execution outcomes for all of it's receipts except for the refund. However, if an account gives approval of withdrawal of [NEP-141] tokens to the FT contract account or a key that belongs to the FT contract account, since `sender_is_receiver`, the `ft_transfer_from` transaction finality would be achieved in one block. This opens up the opportunity to have low-latency transactions on [NEP-141] contracts.
-
-This design also opens the opportunity for token transfer gas costs to be owned by the spender. Potentially, the balance owner would only have to pay for the gas cost of the `ft_approve` function. After that point on, `ft_transfer_from` calls could be payed by the spender. 
+This opens the opportunity for token transfer gas costs to be payed by the spender. Potentially, the balance owner would only have to pay for the gas cost of the `ft_approve` function. After that point on, `ft_transfer_from` calls could be payed by the spender. One small note to consider is that [NEP-366] is solving the transaction costs being payed by a relayer. However, in case of a `ft_transfer` call, the `final transaction execution` would take at least 3 blocks (sender account -> relayer -> ft contract). This might be too slow for certain applications. 
 
 Another use-case is a subscription model. A balancer owner can approve a certain allowance for the spender to withdraw funds on a hourly/monthly/yearly basis. In this case, after initial allowance, balance owner doesn't need to intitate transfers and can take a passive role while the spender could withdraw funds on the allowance. The balance owner can always `cancel` their subscription by removing the allowance. 
 
@@ -28,17 +26,10 @@ Another use-case is a subscription model. A balancer owner can approve a certain
 ## Rationale and alternatives
 Currently there is no way of allowing a third party to withdraw funds based on an allowance. `ft_transfer` transactions have to be initiated by the balance owner. This limits certain use-cases like the one above.
 
-
- 
-
 #### Why is this design the best in the space of possible designs?
 
 This design follows a similar pattern to [ERC-20] approval/allowance pattern that has been widely accepted in the industry and battle-tested. Shortcomings of the pattern is well-known and necessary changes to overcome the shortcomings is explained in this design. (See `ft_approve` function for atomicity)
 
-
-#### What other designs have been considered and what is the rationale for not choosing them?
-
-[Not sure what to put here]
 
 #### What is the impact of not doing this?
 
@@ -199,3 +190,4 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [ERC-20]: https://eips.ethereum.org/EIPS/eip-20
 [NEP-141]: https://github.com/near/NEPs/blob/master/neps/nep-0141.md
 [NEP-21]: https://github.com/near/NEPs/pull/21
+[NEP-366]: https://github.com/near/NEPs/pull/366

--- a/neps/nep-0365.md
+++ b/neps/nep-0365.md
@@ -20,6 +20,8 @@ The current motivation is to delegate to a third party the ability to withdraw f
 
 A valid use-case for using such a flow is when an application needs to have transaction finality in one block. Given the sharded design of NEAR Protocol, `ft_transfer` calls, unless `sender_is_receiver`, would take at least 2 blocks to generate execution outcomes for all of it's receipts except for the refund. However, if an account gives approval of withdrawal of [NEP-141] tokens to the FT contract account or a key that belongs to the FT contract account, since `sender_is_receiver`, the `ft_transfer_from` transaction finality would be achieved in one block. This opens up the opportunity to have low-latency transactions on [NEP-141] contracts.
 
+This design also opens the opportunity for token transfer gas costs to be owned by the spender. Potentially, the balance owner would only have to pay for the gas cost of the `ft_approve` function. After that point on, `ft_transfer_from` calls could be payed by the spender. 
+
 Another use-case is a subscription model. A balancer owner can approve a certain allowance for the spender to withdraw funds on a hourly/monthly/yearly basis. In this case, after initial allowance, balance owner doesn't need to intitate transfers and can take a passive role while the spender could withdraw funds on the allowance. The balance owner can always `cancel` their subscription by removing the allowance. 
 
 


### PR DESCRIPTION
### Summary

An extension to the FT standard that allows users to give allowance to other accounts or keys for transferring NEP-141 tokens on their behalf. 