### PR TITLE
fix: typos and confusing wording in meta transaction spec

### DIFF
--- a/neps/nep-0366.md
+++ b/neps/nep-0366.md
@@ -11,7 +11,7 @@ Created: 19-Oct-2022
 
 ## Summary
 
-In-protocol meta transactions allowing for third-party account to initiate and pay transaction fees on behalf of the account.
+In-protocol meta transactions allow third-party accounts to initiate and pay transaction fees on behalf of the account.
 
 ## Motivation
 
@@ -25,7 +25,7 @@ For example, apps that pay user for doing work (like NEARCrowd or Sweatcoin) or 
 
 The proposed design here provides the easiest way for users and developers to onboard and to pay for user transactions.
 
-An alternative is to a proxy contracts deployed on the user account.
+An alternative is to have a proxy contract deployed on the user account.
 This design has severe limitations as it requires the user to deploy such contract and incur additional costs for storage.
 
 ## Specification
@@ -53,11 +53,11 @@ The main flow of the meta transaction will be as follows:
  ## Limitations
  * If User account exist, then deposit and gas are refunded as usual: gas is refuned to Relayer, deposit is refunded to User.
  * If User account doesn't exist then gas is refunded to Relayer, deposit is burnt.
- * `DelegateAction` actions mustn't contain another `DelegateAction` (`DelegateAction` can't conatin the nested ones).
+ * `DelegateAction` actions mustn't contain another `DelegateAction` (`DelegateAction` can't contain the nested ones).
 
 ### DelegateAction
 
-Delegate actions allows for an account to initiate a batch of actions on behalf of a receiving account, allowing proxy actions. This can be used to implement meta transactions.
+Delegate actions allow an account to initiate a batch of actions on behalf of a receiving account, allowing proxy actions. This can be used to implement meta transactions.
 
 ```rust
 pub struct DelegateAction {
@@ -85,7 +85,7 @@ pub struct SignedDelegateAction {
 }
 ```
 
- Supporting batches of `actions` means `DelegateAction` can be used initiate a complex steps like creating new accounts, transferring funds, deploying contracts, and executing an initialization function all within the same transaction.
+ Supporting batches of `actions` means `DelegateAction` can be used to initiate complex steps like creating new accounts, transferring funds, deploying contracts, and executing an initialization function all within the same transaction.
 
 ***Validation***:
 1. Validate `DelegateAction` doesn't contain a nested `DelegateAction` in actions.
@@ -103,10 +103,10 @@ struct DelegateActionMessage {
 ```
 
 The next set of security concerns are addressed by this format:
- - `sender_id` is included to ensure that the relayer set correct `transaction.receiver_id`.
+ - `sender_id` is included to ensure that the relayer sets the correct `transaction.receiver_id`.
  - `max_block_height` is included to ensure that the `DelegateAction` isn't expired.
  - `nonce` is included to ensure that the `DelegateAction` can't be replayed again.
- - `public_key` and `sender_id` are needed to ensure that on the right account, work across rotating keys and fetch correct `nonce`.
+ - `public_key` and `sender_id` are needed to ensure that on the right account, work across rotating keys and fetch the correct `nonce`.
 
 The permissions are verified based on the variant of `public_key`:
  - `AccessKeyPermission::FullAccess`, all actions are allowed.
@@ -181,7 +181,7 @@ See the [DelegateAction specification](/specs/RuntimeSpec/Actions.md#DelegateAct
 
 ## Security Implications
 
-Delegate actions do not override `signer_public_key`, leaving that to the original signer that initiated transaction (e.g. the relayer in the meta transaction case). Although it is possible to override the `signer_public_key` in the context with one from the `DelegateAction`, there is no clear value in that.
+Delegate actions do not override `signer_public_key`, leaving that to the original signer that initiated the transaction (e.g. the relayer in the meta transaction case). Although it is possible to override the `signer_public_key` in the context with one from the `DelegateAction`, there is no clear value in that.
 
 See the ***Validation*** section in [DelegateAction specification](/specs/RuntimeSpec/Actions.md#DelegateAction) for security considerations around what the user signs and the validation of actions with different permissions.
 
@@ -190,7 +190,7 @@ See the ***Validation*** section in [DelegateAction specification](/specs/Runtim
 * Increases complexity of NEAR's transactional model.
 * Meta transactions take an extra block to execute, as they first need to be included by the originating account, then routed to the delegate account, and only after that to the real destination.
 * User can't call functions from different contracts in same `DelegateAction`. This is because `DelegateAction` has only one receiver for all inner actions.
-* The Relayer must verify the most of parameters before submitting `DelegateAction`, making sure that one of the function calls is the reward action. Either way, this is a risk for Relayer in general.
+* The Relayer must verify most of the parameters before submitting `DelegateAction`, making sure that one of the function calls is the reward action. Either way, this is a risk for Relayer in general.
 * User must not trust Relayer’s response and should check execution errors in Blockchain.
 
 ## Future possibilities


### PR DESCRIPTION
Some things I noticed when looking over the meta transactions spec. I have no opinion if this comes in or not, but might make this more clear.