### PR TITLE
NEP-455: Parameter Compute Costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Changes to the protocol specification and standards are called NEAR Enhancement 
 |[0330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)   | Source Metadata | @BenKurrek                                  | Review |
 |[0366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md)   | Meta Transactions | @ilblackdragon @e-uleyskiy @fadeevab        | Draft  |
 |[0399](https://github.com/near/NEPs/blob/master/neps/nep-0399.md)   | Flat Storage | @Longarithm @mzhangmzz                      | Review |
+|[0455](https://github.com/near/NEPs/blob/master/neps/nep-0455.md)   | Parameter Compute Costs | @akashin @jakmeier | Final |
 
 
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -1,0 +1,219 @@
+---
+NEP: 455
+Title: Parameter Compute Costs
+Author: Andrei Kashin <andrei.kashin@near.org>, Jakob Meier <jakob@near.org>
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/455
+Status: Draft
+Type: Protocol Track
+Category: Runtime
+Created: 26-Jan-2023
+---
+
+## Summary
+
+Introduce compute costs decoupled from gas costs for individual parameters to safely limit the compute time it takes to process the chunk while avoiding adding breaking changes for contracts.
+
+## Motivation
+
+For NEAR blockchain stability, we need to ensure that blocks are produced regularly and in a timely manner.
+
+The chunk gas limit is used to ensure that the time it takes to validate a chunk is strictly bounded by limiting the total gas cost of operations included in the chunk.
+This process relies on accurate estimates of gas costs for individual operations.
+
+Underestimating these costs leads to *undercharging* which can increase the chunk validation time and slow down the chunk production.
+
+As a concrete example, in the past we undercharged contract deployment.
+The responsible team has implemented a number of optimizations but a gas increase was still necessary.
+[Meta-pool](https://github.com/Narwallets/meta-pool/issues/21) and [Sputnik-DAO](https://github.com/near-daos/sputnik-dao-contract/issues/135) were affected by this change, among others.
+Finding all affected parties and reaching out to them before implementing the change took a lot of effort, prolonging the period where the network was exposed to the attack.
+
+Another motivating example is the upcoming incremental deployment of Flat Storage, where during one of the intermediate stages we expect the storage operations to be undercharged.
+See the explanation in the next section for more details.
+
+## Rationale
+
+Separating compute costs from gas costs will allow us to safely limit the compute usage for processing the chunk while still keeping the gas prices the same and thus not breaking existing contracts.
+
+An important challenge with undercharging is that it is not possible to disclose them widely because it could be used to increase the chunk production time thereby impacting the stability of the network.
+Adjusting the compute cost for undercharged parameter eliminates the security concern and allows us to publicly discuss the ways to solve the undercharging (optimize implementation, smart contract or increasing the gas cost).
+
+This design is easy to implement and simple to reason about and provides a clear way to address existing undercharging issues.
+If we don't address the undercharging problems, we increase the risks that they will be exploited.
+
+Specifically for Flat Storage deployment, we [plan](https://github.com/near/nearcore/issues/8006) to stop charging TTN (touching trie node) gas costs, however the intermediate implementation (read-only Flat Storage) will still incur these costs during writes introducing undercharging.
+Setting temporary high compute costs for writes will ensure that this undercharging does not lead to long chunk processing times.
+
+## Alternatives
+
+### Increase the gas costs for undercharged operations
+We could increase the gas costs for the operations that are undercharged to match the computational time it takes to process them according to the rule 1ms = 1TGas.
+
+Pros:
+- Does not require any new code or design work (but still requires a protocol version bump)
+- Security implications are well-understood
+
+Cons:
+- Can break contracts that rely on current gas costs, in particular steeply increasing operating costs for the most active users of the blockchain (aurora and sweat)
+- Doing this safely and responsibly requires prior consent by the affected parties which is hard to do without disclosing security-sensitive information about undercharging in public
+
+In case of flat storage specifically, using this approach will result in a large increase in storage write costs (breaking many contracts) to enable safe deployment of read-only flat storage and later a correction of storage write costs when flat storage for writes is rolled out.
+With compute costs, we will be able to roll out the read-only flat storage with minimal impact on deployed contracts.
+
+### Adjust the gas chunk limit
+We could continuously measure the chunk production time in nearcore clients and compare it to the gas burnt.
+If the chunk producer observes undercharging, it decreases the limit.
+If there is overcharging, the limit can be increased up to a limit of at most 1000 Tgas.
+To make such adjustment more predictable under spiky load, we also [limit](https://nomicon.io/Economics/Economic#transaction-fees) the magnitude of change of gas limit by 0.1% per block.
+
+Pros:
+- Prevents moderate undercharging from stalling the network
+- No protocol change necessary (as this feature is already [a part of the protocol](https://nomicon.io/Economics/Economic#transaction-fees)), we could easily experiment and revert if it does not work well
+
+Cons:
+- Very broad granularity --- undercharging in one parameter affects all users, even those that never use the undercharged parts
+- Dependence on validator hardware --- someone running overspecced hardware will continuously want to increase the limit, others might run with underspecced hardware and continuously want to decrease the limit
+- Malicious undercharging attacks are unlikely to be prevented by this --- a single 10x undercharged receipt still needs to be processed using the old limit.
+Adjusting 0.1% per block means 100 chunks can only change by a maximum of 1.1x and 1000 chunks could change up to x2.7
+- Conflicts with transaction and receipt limit --- A transaction or receipt can (today) use up to 300Tgas.
+The effective limit per chunk is `gas_limit` + 300Tgas since receipts are added to a chunk until one exceeds the limit and the last receipt is not removed.
+Thus a gas limit of 0gas only reduces the effective limit from 1300Tgas to 300Tgas, which means a single 10x undercharged receipt can still result in a chunk with compute usage of 3 seconds (equivalent to 3000TGas)
+
+### Allow skipping chunks in the chain
+Slow chunk production in one shard can introduce additional user-visible latency in all shards as the nodes expect a regular and timely chunk production during normal operation.
+If processing the chunk takes much longer than 1.3s, it can cause the corresponding block and possibly more consecutive blocks to be skipped.
+
+We could extend the protocol to produce empty chunks for some of the shards within the block (effectively skipping them) when processing the chunk takes longer than expected.
+This way will still ensure a regular block production, at a cost of lower throughput of the network in that shard.
+The chunk should still be included in a later block to avoid stalling the affected shard.
+
+Pros:
+- Fast and automatic adaptation to the blockchain workload
+
+Cons:
+- Needs a voting mechanism to decide that processing of the chunk is slow (as opposed to the chunk producer being slow) and the chunk should be skipped within a block
+- Needs economic design for the rewards for skipped chunks
+
+## Specification
+
+- **Chunk Compute Usage** -- total compute time spent on processing the chunk
+
+- **Chunk Compute Limit** -- upper-bound for compute time spent on processing the chunk
+
+- **Parameter Compute Cost** -- the numeric value in seconds corresponding to compute time that it takes to include an operation into the chunk
+
+Today, gas has two somewhat orthogonal roles:
+
+1. Gas is money. It is used to avoid spam by charging users
+2. Gas is CPU time. It defines how many transactions fit in a chunk so that validators can apply it within a second
+
+The idea is to decouple these two by introducing parameter compute costs.
+Each gas parameter still has a gas cost that determines what users have to pay.
+But when filling a chunk with transactions, parameter compute cost is used to estimate CPU time.
+
+Ideally, all compute costs should match corresponding gas costs.
+But when we discover undercharging issues, we can set a higher compute cost (this would require a protocol upgrade).
+The stability concern is then resolved when the compute cost becomes active.
+
+The ratio between compute cost and gas cost can be thought of as an undercharging factor.
+If a gas cost is 2 times too low to guarantee stability, compute cost will be twice the gas cost.
+A chunk will be full 2 times faster when gas for this parameter is burned.
+This deterministically throttles the throughput to match what validators can actually handle.
+
+Compute costs influence the gas price adjustment logic described in https://nomicon.io/Economics/Economic#transaction-fees.
+Specifically, we're now using compute usage instead of gas usage in the formula to make sure that the gas price increases if chunk processing time is close to the limit.
+
+Compute costs **do not** count towards the transaction/receipt gas limit of 300TGas, as that might break existing contracts by pushing their method calls over this limit.
+
+Compute costs are static for each protocol version.
+
+### Using Compute Costs
+Compute costs different from gas costs are only a temporary solution.
+Whenever we introduce a compute cost, we as the community can discuss this publicly and find a solution to the specific problem together.
+
+In the best case, we find technical optimizations that allow us to decrease the compute cost to match the existing gas cost.
+
+In other cases, the only solution is to increase the gas cost.
+But the dApp developers who are affected by this change should have a chance to voice their opinion, suggest alternatives, and implement necessary changes before the gas cost is increased.
+
+## Reference Implementation
+
+The reference implementation can be found at https://github.com/near/nearcore/pull/8426.
+
+The compute cost is a numeric value represented as `u64` in time units.
+Value 1 corresponds to `10^-15` seconds or 1fs (femtosecond) to match the gas costs scale.
+
+By default, the parameter compute cost matches the corresponding gas cost.
+
+Compute costs should be applicable to all gas parameters, specifically including:
+- [`ExtCosts`](https://cs.github.com/near/nearcore/blob/6e08a41084c632010b1d4c42132ad58ecf1398a2/core/primitives-core/src/config.rs#L377)
+- [`ActionCosts`](https://cs.github.com/near/nearcore/blob/6e08a41084c632010b1d4c42132ad58ecf1398a2/core/primitives-core/src/config.rs#L456)
+
+Changes necessary to support `ExtCosts`:
+1. Track compute usage in [`GasCounter`](https://cs.github.com/near/nearcore/blob/51670e593a3741342a1abc40bb65e29ba0e1b026/runtime/near-vm-logic/src/gas_counter.rs#L47) struct
+2. Track compute usage in [`VMOutcome`](https://cs.github.com/near/nearcore/blob/056c62183e31e64cd6cacfc923a357775bc2b5c9/runtime/near-vm-logic/src/logic.rs#L2868) struct (alongside `burnt_gas` and `used_gas`)
+3. Store compute usage in [`ActionResult`](https://cs.github.com/near/nearcore/blob/6d2f3fcdd8512e0071847b9d2ca10fb0268f469e/runtime/runtime/src/lib.rs#L129) and aggregate it across multiple actions by modifying [`ActionResult::merge`](https://cs.github.com/near/nearcore/blob/6d2f3fcdd8512e0071847b9d2ca10fb0268f469e/runtime/runtime/src/lib.rs#L141)
+4. Store compute costs in [`ExecutionOutcome`](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/runtime/runtime/src/lib.rs#L266) and [aggregate them across all transactions](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/runtime/runtime/src/lib.rs#L1279)
+5. Enforce the chunk compute limit when the chunk is [applied](https://cs.github.com/near/nearcore/blob/6d2f3fcdd8512e0071847b9d2ca10fb0268f469e/runtime/runtime/src/lib.rs#L1325)
+
+Additional changes necessary to support `ActionCosts`:
+1. Return compute costs from [`total_send_fees`](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/runtime/runtime/src/config.rs#L71)
+2. Store aggregate compute cost in [`TransactionCost`](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/runtime/runtime/src/config.rs#L22) struct
+3. Propagate compute costs to [`VerificationResult`](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/runtime/runtime/src/verifier.rs#L330)
+
+Additionaly, the gas price computation will need to be adjusted in [`compute_new_gas_price`](https://cs.github.com/near/nearcore/blob/578983c8df9cc36508da2fb4a205c852e92b211a/core/primitives/src/block.rs#L328) to use compute cost instead of gas cost.
+
+## Security Implications
+
+Changes in compute costs will be publicly known and might reveal an undercharging that can be used as a target for the attack.
+In practice, it is not trivial to exploit the undercharging unless you know the exact shape of the workload that realizes it.
+Also, after the compute cost is deployed, the undercharging should no longer be a threat for the network stability.
+
+## Drawbacks
+
+- Changing compute costs requires a protocol version bump (and a new binary release), limiting their use to undercharging problems that we're aware of
+
+- Updating compute costs is a manual process and requires deliberately looking for potential underchargings
+
+- The compute cost would not have a full effect on the last receipt in the chunk, decreasing its effectiveness to deal with undercharging.
+This is because 1) a transaction or receipt today can use up to 300TGas and 2) receipts are added to a chunk until one exceeds the limit and the last receipt is not removed.
+Therefore, a single receipt with 300TGas filled with undercharged operations with a factor of K can lead to overshooting the chunk compute limit by (K - 1) * 300TGas
+
+- Underchargings can still be exploited to lower the throughput of the network at unfair price and increase the waiting times for other users.
+This is inevitable for any proposal that doesn't change the gas costs and must be resolved by improving the performance or increasing the gas costs
+
+- Even without malicious intent, the effective peak throughput of the network will decrease when the chunks include undercharged operations (as the stopping condition based on compute costs for filling the chunk becomes stricter).
+Most of the time, this is not the problem as the network is operating below the capacity.
+The effects will also be softened by the fact that undercharged operations comprise only a fraction of the workload.
+For example, the planned increase for TTN compute cost alongside the Flat Storage MVP is less critical because you cannot fill a receipt with only TTN costs, you will always have other storage costs and ~5Tgas overhead to even start a function call.
+So even with 10x difference between gas and compute costs, the DoS only becomes 5x cheaper instead of 10x
+
+## Unresolved Issues
+
+## Future possibilities
+We can also think about compute costs smaller than gas costs.
+For example, we charge gas instead of token balance for extra storage bytes in [NEP-448](https://github.com/near/NEPs/pull/448), it would make sense to set the compute cost to 0 for the part that covers on-chain storage if the throttling due to increased gas cost becomes problematic.
+Otherwise, the throughput would be throttled unnecessarily.
+
+A further option would be to change compute costs dynamically without a protocol upgrade when block production has become too slow.
+This would be a catch-all, self-healing solution that requires zero intervention from anyone.
+The network would simply throttle throughput when block time remains too high for long enough.
+Pursuing this approach would require additional design work:
+- On-chain voting to agree on new values of costs, given that inputs to the adjustment process are not deterministic (measurements of wall clock time it takes to process receipt on particular validator)
+- Ensuring that dynamic adjustment is done in a safe way that does not lead to erratic behavior of costs (and as a result unpredictable network throughput).
+Having some experience manually operating this mechanism would be valuable before introducing automation
+
+and addressing challenges described in https://github.com/near/nearcore/issues/8032#issuecomment-1362564330.
+
+The idea of introducing a chunk limit for compute resource usage naturally extends to other resource types, for example RAM usage, Disk IOPS, [Background CPU Usage](https://github.com/near/nearcore/issues/7625).
+This would allow us to align the pricing model with cloud offerings familiar to many users, while still using gas as a common denominator to simplify UX.
+
+## Copyright
+
+[copyright]: #copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+
+## References
+- https://gov.near.org/t/proposal-gas-weights-to-fight-instability-to-due-to-undercharging/30919
+- https://github.com/near/nearcore/issues/8032

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -207,6 +207,25 @@ and addressing challenges described in https://github.com/near/nearcore/issues/8
 The idea of introducing a chunk limit for compute resource usage naturally extends to other resource types, for example RAM usage, Disk IOPS, [Background CPU Usage](https://github.com/near/nearcore/issues/7625).
 This would allow us to align the pricing model with cloud offerings familiar to many users, while still using gas as a common denominator to simplify UX.
 
+## Changelog
+
+### 1.0.0 - Initial Version
+
+This NEP was approved by Protocol Working Group members on March 16th, 2023 ([meeting recording](https://www.youtube.com/watch?v=4VxRoKwLXIs)):
+
+- [Bowen](https://github.com/near/NEPs/pull/455#issuecomment-1467023424)
+- [Marcelo](https://github.com/near/NEPs/pull/455#pullrequestreview-1340887413)
+- [Marcin](https://github.com/near/NEPs/pull/455#issuecomment-1471882639)
+
+#### Benefits
+
+- Among the alternatives, this is the easiest to implement.
+- It allows us to able to publicly discuss undercharging issues before they are fixed. 
+
+#### Concerns
+
+No concerns that need to be addressed. The drawbacks listed in this NEP are minor compared to the benefits that it will bring. And implementing this NEP is strictly better than what we have today.
+
 ## Copyright
 
 [copyright]: #copyright

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -90,8 +90,7 @@ Pros:
 - Fast and automatic adaptation to the blockchain workload
 
 Cons:
-- Needs a voting mechanism to decide that processing of the chunk is slow (as opposed to the chunk producer being slow) and the chunk should be skipped within a block
-- Needs economic design for the rewards for skipped chunks
+- For the purpose of slashing, it is hard to distinguish situations when the honest block producer skips chunk due to slowness from the situations when the block producer is offline or is maliciously stalling the block production. We need some mechanism (e.g. on-chain voting) for nodes to agree that the chunk was skipped legitimately due to slowness as otherwise we introduce new attack vectors to stall the network
 
 ## Specification
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -211,11 +211,11 @@ This would allow us to align the pricing model with cloud offerings familiar to 
 
 ### 1.0.0 - Initial Version
 
-This NEP was approved by Protocol Working Group members on March 16th, 2023 ([meeting recording](https://www.youtube.com/watch?v=4VxRoKwLXIs)):
+This NEP was approved by Protocol Working Group members on March 16, 2023 ([meeting recording](https://www.youtube.com/watch?v=4VxRoKwLXIs)):
 
-- [Bowen](https://github.com/near/NEPs/pull/455#issuecomment-1467023424)
-- [Marcelo](https://github.com/near/NEPs/pull/455#pullrequestreview-1340887413)
-- [Marcin](https://github.com/near/NEPs/pull/455#issuecomment-1471882639)
+- [Bowen's vote](https://github.com/near/NEPs/pull/455#issuecomment-1467023424)
+- [Marcelo's vote](https://github.com/near/NEPs/pull/455#pullrequestreview-1340887413)
+- [Marcin's vote](https://github.com/near/NEPs/pull/455#issuecomment-1471882639)
 
 #### Benefits
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -137,8 +137,6 @@ But the dApp developers who are affected by this change should have a chance to 
 
 ## Reference Implementation
 
-The reference implementation can be found at https://github.com/near/nearcore/pull/8426.
-
 The compute cost is a numeric value represented as `u64` in time units.
 Value 1 corresponds to `10^-15` seconds or 1fs (femtosecond) to match the gas costs scale.
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -129,6 +129,8 @@ Compute costs are static for each protocol version.
 Compute costs different from gas costs are only a temporary solution.
 Whenever we introduce a compute cost, we as the community can discuss this publicly and find a solution to the specific problem together.
 
+For any active compute cost, a tracking GitHub issue in [`nearcore`](https://github.com/near/nearcore) should be created, tracking work towards resolving the undercharging. The reference to this issue should be added to this NEP.
+
 In the best case, we find technical optimizations that allow us to decrease the compute cost to match the existing gas cost.
 
 In other cases, the only solution is to increase the gas cost.


### PR DESCRIPTION
NEP for Parameter Compute Costs (formerly known as Parameter Weights).

For the context, this NEP was previously named "Parameter Weights" and the idea was originally proposed in https://gov.near.org/t/proposal-gas-weights-to-fight-instability-to-due-to-undercharging/30919.
Now it's renamed into "Parameter Compute Cost" to more accurately represent the fact that it is about accounting how much compute time the parameters cost and using it to limit the chunk processing time.