### PR TITLE
update NEP-455: storage compute costs for v61

### DIFF
--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -233,7 +233,27 @@ This NEP was approved by Protocol Working Group members on March 16, 2023 ([meet
 
 ### 1.0.1 - Storage Related Compute Costs
 
-- Add five compute cost values for protocol version 61 and above. Details in https://github.com/near/nearcore/issues/8938.
+Add five compute cost values for protocol version 61 and above.
+ - wasm_touching_trie_node
+ - wasm_storage_write_base
+ - wasm_storage_remove_base
+ - wasm_storage_read_base
+ - wasm_storage_has_key_base
+
+For the exact values, please refer to the table at the bottom.
+
+The intention behind these increased compute costs is to address the issue of
+storage accesses taking longer than the allocated gas costs, particularly in
+cases where RocksDB, the underlying storage system, is too slow. These values
+have been chosen to ensure that validators with recommended hardware can meet
+the required timing constraints.
+([Analysis Report](https://github.com/near/nearcore/issues/8006))
+
+The protocol team at Pagoda is actively working on optimizing the nearcore
+client storage implementation. This should eventually allow to lower the compute
+costs parameters again.
+
+Progress on this work is tracked here: https://github.com/near/nearcore/issues/8938.
 
 #### Benefits
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -259,8 +259,8 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 Parameter Name | Compute / Gas factor | First version | Last version | Tracking issue |
 -------------- | -------------------- | ------------- | ------------ | -------------- |
-wasm_touching_trie_node       |  6.83 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
-wasm_storage_write_base       |  3.12 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
-wasm_storage_remove_base      |  3.74 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
-wasm_storage_read_base        |  3.55 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
-wasm_storage_has_key_base     |  3.70 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_touching_trie_node       |  6.83 |            61 |        *TBD* | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_write_base       |  3.12 |            61 |        *TBD* | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_remove_base      |  3.74 |            61 |        *TBD* | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_read_base        |  3.55 |            61 |        *TBD* | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_has_key_base     |  3.70 |            61 |        *TBD* | [nearcore#8938](https://github.com/near/nearcore/issues/8938)

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -231,6 +231,10 @@ This NEP was approved by Protocol Working Group members on March 16, 2023 ([meet
 - [Marcelo's vote](https://github.com/near/NEPs/pull/455#pullrequestreview-1340887413)
 - [Marcin's vote](https://github.com/near/NEPs/pull/455#issuecomment-1471882639)
 
+### 1.0.1 - Storage Related Compute Costs
+
+- Five compute cost value are added for protocol version 61 and above. Details in https://github.com/near/nearcore/issues/8938.
+
 #### Benefits
 
 - Among the alternatives, this is the easiest to implement.
@@ -250,3 +254,13 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 - https://gov.near.org/t/proposal-gas-weights-to-fight-instability-to-due-to-undercharging/30919
 - https://github.com/near/nearcore/issues/8032
+
+## Live Compute Costs Tracking
+
+Parameter Name | Compute / Gas factor | First version | Last version | Tracking issue |
+-------------- | -------------------- | ------------- | ------------ | -------------- |
+wasm_touching_trie_node       |  6.83 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_write_base       |  3.12 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_remove_base      |  3.74 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_read_base        |  3.55 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)
+wasm_storage_has_key_base     |  3.70 |            61 |        _TBD_ | [nearcore#8938](https://github.com/near/nearcore/issues/8938)

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -233,7 +233,7 @@ This NEP was approved by Protocol Working Group members on March 16, 2023 ([meet
 
 ### 1.0.1 - Storage Related Compute Costs
 
-- Five compute cost value are added for protocol version 61 and above. Details in https://github.com/near/nearcore/issues/8938.
+- Add five compute cost values for protocol version 61 and above. Details in https://github.com/near/nearcore/issues/8938.
 
 #### Benefits
 

--- a/neps/nep-0455.md
+++ b/neps/nep-0455.md
@@ -234,11 +234,12 @@ This NEP was approved by Protocol Working Group members on March 16, 2023 ([meet
 ### 1.0.1 - Storage Related Compute Costs
 
 Add five compute cost values for protocol version 61 and above.
- - wasm_touching_trie_node
- - wasm_storage_write_base
- - wasm_storage_remove_base
- - wasm_storage_read_base
- - wasm_storage_has_key_base
+
+- wasm_touching_trie_node
+- wasm_storage_write_base
+- wasm_storage_remove_base
+- wasm_storage_read_base
+- wasm_storage_has_key_base
 
 For the exact values, please refer to the table at the bottom.
 


### PR DESCRIPTION
Tracks the newly introduced compute costs for protocol version 61.

(draft: the changes are still being merged in, I plan to mark this PR ready for review once the testnet release has been cut and confirmed to include the relevant compute cost values.)