### PR TITLE
fix: Remove reference to storage rent

### DIFF
--- a/specs/DataStructures/Account.md
+++ b/specs/DataStructures/Account.md
@@ -151,7 +151,9 @@ Every account has its own storage. It's a persistent key-value trie. Keys are or
 The storage can only be modified by the contract on the account.
 Current implementation on Runtime only allows your account's contract to read from the storage, but this might change in the future and other accounts's contracts will be able to read from your storage.
 
-NOTE: Accounts are charged recurrent rent for the total storage. This includes storage of the account itself, contract code, contract storage and all access keys.
+NOTE: To pay for blockchain storage, the protocol locks a token amount per account proportional to its state size.
+This includes storage of the account itself, contract code, contract storage and all access keys.
+See [Storage Staking](https://docs.near.org/concepts/storage/storage-staking) in the docs.
 
 #### Access Keys
 


### PR DESCRIPTION
Storage rent has been superseded by storage staking a long time ago.
This commit updates the account specification accordingly.