### PR TITLE
fix: inaccuracies in delegate action errors

### DIFF
--- a/neps/nep-0366.md
+++ b/neps/nep-0366.md
@@ -3,10 +3,12 @@ NEP: 366
 Title: Meta Transactions
 Author: Illia Polosukhin <ilblackdragon@gmail.com>, Egor Uleyskiy (egor.ulieiskii@gmail.com), Alexander Fadeev (fadeevab.com@gmail.com)
 DiscussionsTo: https://github.com/nearprotocol/neps/pull/366
-Status: Draft
+Status: Approved
 Type: Protocol Track
 Category: Runtime
+Version: 1.1.0
 Created: 19-Oct-2022
+LastUpdated: 03-Aug-2023
 ---
 
 ## Summary
@@ -149,7 +151,7 @@ DelegateActionInvalidSignature
 
 ```rust
 /// Receiver of the transaction doesn't match Sender of the delegate action
-DelegateActionSenderDoesNotMatchReceiver
+DelegateActionSenderDoesNotMatchTxReceiver
 ```
 
 - If the current block is equal or greater than `max_block_height`
@@ -180,13 +182,6 @@ DelegateActionInvalidNonce
 DelegateActionNonceTooLarge
 ```
 
-- If the list of delegated actions contains another `DelegateAction`
-
-```rust
-/// DelegateAction actions contain another DelegateAction
-DelegateActionCantContainNestedOne
-```
-
 - If the list of Transaction actions contains several `DelegateAction`
 
 ```rust
@@ -213,6 +208,13 @@ See the **_Validation_** section in [DelegateAction specification](/specs/Runtim
 ## Future possibilities
 
 Supporting ZK proofs instead of just signatures can allow for anonymous transactions, which pay fees to relayers anonymously.
+
+## Changelog
+
+### 1.1.0 - Adjust errors to reflect deployed reality (03-Aug`2023)
+
+- Remove the error variant `DelegateActionCantContainNestedOne` because this would already fail in the parsing stage.
+- Rename the error variant `DelegateActionSenderDoesNotMatchReceiver` to `DelegateActionSenderDoesNotMatchTxReceiver` to reflect published types in [near_primitives](https://docs.rs/near-primitives/0.17.0/near_primitives/errors/enum.ActionErrorKind.html#variant.DelegateActionSenderDoesNotMatchTxReceiver).
 
 ## Copyright
 


### PR DESCRIPTION
While updating the specs for delegate actions, I noticed that there are two small mistakes in the error description of the NEP. Or I guess it would be more accurate to say the nearcore implementation is not compliant with the NEP.

1) `DelegateActionCantContainNestedOne` is impossible to happen because the chosen serialization format does not allow nesting in the first place.
2) The name for `DelegateActionSenderDoesNotMatchReceiver` somehow managed to get even longer in the real implementation and now spells `DelegateActionSenderDoesNotMatchTxReceiver`

I know this isn't ideal. But since this is now de-facto part of the protocol, I suggest we update the NEP to reflect it. Alternatively, we could change it in nearcore. This would be a breaking change in some primitives crates, so I tend towards the first option.