### PR TITLE
nep-393: add bool return to sbt_revoke_by_owner

### DIFF
--- a/neps/nep-0393.md
+++ b/neps/nep-0393.md
@@ -405,10 +405,8 @@ trait SBTRegistry {
     fn sbt_revoke(&mut self, tokens: Vec<TokenId>, burn: bool);
 
     /// Similar to `sbt_revoke`. Allows SBT issuer to revoke all tokens by holder either by
-    /// burning or updating their expire time. The function will try to revoke
-    /// at most `MAX_REVOKE_PER_CALL` tokens (to fit into the tx gas limit),
-    /// so when an owner has many tokens from the issuer, the issuer may need to
-    /// call this function multiple times, until all tokens are revoked.
+    /// burning or updating their expire time. When an owner has many tokens from the issuer,
+    /// the issuer may need to call this function multiple times, until all tokens are revoked.
     /// Retuns true if all the tokens were revoked, false otherwise.
     /// If false is returned issuer must call the method until true is returned
     /// Must be called by an SBT contract.

--- a/neps/nep-0393.md
+++ b/neps/nep-0393.md
@@ -404,8 +404,17 @@ trait SBTRegistry {
     /// Must also emit `Burn` event if the SBT tokens are burned (removed).
     fn sbt_revoke(&mut self, tokens: Vec<TokenId>, burn: bool);
 
-    /// Similar to `sbt_revoke`, but revokes all `owner`s tokens issued by the caller.
-    fn sbt_revoke_by_owner(&mut self, owner: AccountId, burn: bool);
+    /// Similar to `sbt_revoke`. Allows SBT issuer to revoke all tokens by holder either by
+    /// burning or updating their expire time. The function will try to revoke
+    /// at most `MAX_REVOKE_PER_CALL` tokens (to fit into the tx gas limit),
+    /// so when an owner has many tokens from the issuer, the issuer may need to
+    /// call this function multiple times, until all tokens are revoked.
+    /// Retuns true if all the tokens were revoked, false otherwise.
+    /// If false is returned issuer must call the method until true is returned
+    /// Must be called by an SBT contract.
+    /// Must emit `Revoke` event.
+    /// Must also emit `Burn` event if the SBT tokens are burned (removed).
+    fn sbt_revoke_by_owner(&mut self, owner: AccountId, burn: bool) -> bool;
 
     /// Allows issuer to update token metadata reference and reference_hash.
     /// * `updates` is a list of triples: (token ID, reference, reference base64-encoded sha256 hash).


### PR DESCRIPTION
In the [reference](https://github.com/near-ndc/i-am-human/blob/cfc92b1/contracts/registry/src/registry.rs#L362) implementation we return `bool` in the `registry.sbt_revoke_by_owner` to signal if the operation should continue or it's finished.

We forgot to push this update to the standard.

This update also makes the API consistent with `sbt_recover` and `sbt_soul_transfer`