### PR TITLE
NEP-330 extension: Build details extension

### DIFF
--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -78,6 +78,7 @@ When using a Docker image as a reference, it's important to specify the digest o
 ### Paths Inside Docker Image
 
 During the build, paths from the source of the build as well as the location of the cargo registry could be saved into WASM, which affects reproducibility. Therefore, we need to ensure that everyone uses the same paths inside the Docker image. We propose using the following paths:
+
 - `/home/near/code` - Mounting volume from the host system containing the source code.
 - `/home/near/.cargo` - Cargo registry.
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -58,8 +58,8 @@ type Standard {
 type BuildInfo {
     build_environment_ref: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
-	  contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
-	  build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
+    contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+    build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
 }
 ```
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -47,7 +47,7 @@ type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
   link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
   standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
-  build_details: BuildDetails|null, // optional, details that are required for contract WASM reproducibility.
+  build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
 
 type Standard {

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -31,22 +31,35 @@ There is a lot of information that can be held about a contract. Ultimately, we 
 
 Successful implementations of this standard will introduce a new  (`ContractSourceMetadata`) struct that will hold all the necessary information to be queried for. This struct will be kept on the contract level.
 
-The metadata will include three optional fields:
+The metadata will include optional fields:
 
-- `version`: a string that references the specific commit hash or version of the code that is currently deployed on-chain. This can be included regardless of whether or not the contract is open-sourced and can also be used for organizational purposes.
+- `version`: a string that references the specific commit hash or version of the code currently deployed on-chain. If the link is to a GitHub repo URL, this is crucial, as it is needed to make the contract reproducible.
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
+- `build_details`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
 
 ```ts
 type ContractSourceMetadata = {
   version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
   link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
   standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+  build_details: BuildDetails|null, // optional, details that are required for contract WASM reproducibility.
 }
 
 type Standard {
     standard: string, // standard name e.g. "nep141"
     version: string, // semantic version number of the Standard e.g. "1.0.0"
+}
+
+type BuildDetails {
+	env_image: EnvImage, // reference to a reproducible build environment image, e.g. "{tag: "sourcescan/cargo-near:0.6.0", digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"}"
+	contract_path: string|null // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+	build_command: string[] // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
+}
+
+type EnvImage {
+	tag: string // tag of the image e.g. "sourcescan/cargo-near:0.6.0"
+	digest: string // a sha256 hash unique, immutable identifier for a container image, used to verify that the image under the same tag has not changed e.g. "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
 }
 ```
 
@@ -58,30 +71,39 @@ function contract_source_metadata(): ContractSourceMetadata {}
 
 ## Reference Implementation
 
-As an example, say there was an NFT contract deployed on-chain which was currently using the commit hash `39f2d2646f2f60e18ab53337501370dc02a5661c` and had its open source code located at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct which has the following fields:
+As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment image `sourcescan/cargo-near:0.6.0`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
 
 ```ts
 type ContractSourceMetadata = {
-  version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
+  version: "39f2d2646f2f60e18ab53337501370dc02a5661c",
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
-        standard: "nep330", 
-        version: "1.1.0"
+      standard: "nep330",
+      version: "1.1.0"
     },
     {
-        standard: "nep171", 
-        version: "1.0.0"
+      standard: "nep171",
+      version: "1.0.0"
     },
     {
-        standard: "nep177", 
-        version: "2.0.0"
+      standard: "nep177",
+      version: "2.0.0"
     }
-  ]
+  ],
+  build_details: {
+    env_image: {
+      tag: "sourcescan/cargo-near:0.6.0",
+      digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
+    },
+    contract_path: "nft-contract",
+    build_command: ["cargo", "near", "deploy", "--no-abi"]
+  }
 }
+
 ```
 
-If someone were to call the view function `contract_metadata`, the contract would return:
+Calling the view function `contract_metadata`, the contract would return:
 
 ```bash
 {
@@ -100,9 +122,19 @@ If someone were to call the view function `contract_metadata`, the contract woul
             standard: "nep177", 
             version: "2.0.0"
         }
-    ]
+    ],
+    build_details: {
+	    env_image: {
+	      tag: "sourcescan/cargo-near:0.6.0",
+	      digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
+	    },
+	    contract_path: "nft-contract",
+	    build_command: ["cargo", "near", "deploy", "--no-abi"]
+	}
 }
 ```
+
+This could be used by SourceScan to reproduce the same WASM using the build details and to verify the on-chain WASM code with the reproduced one.
 
 An example implementation can be seen below.
 
@@ -113,17 +145,31 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
-// Standard structure
+/// Standard structure
 pub struct Standard {
     pub standard: String,
     pub version: String
 }
 
+/// EnvImage structure
+pub struct EnvImage { 
+	pub tag: String, 
+	pub digest: String, 
+}
+
+/// BuildDetails structure
+pub struct BuildDetails { 
+	pub env_image: EnvImage, 
+	pub contract_path: Option<String>, 
+	pub build_command: Vec<String>, 
+}
+
 /// Contract metadata structure
 pub struct ContractSourceMetadata {
-    pub version: String,
-    pub link: String,
-    pub standards: Vec<Standard>
+    pub version: Option<String>,
+    pub link: Option<String>,
+    pub standards: Option<Vec<Standard>>,
+    pub build_details: Option<BuildDetails>,
 }
 
 /// Minimum Viable Interface

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -58,7 +58,7 @@ type Standard {
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
-    contract_path: string|null, // relative path to contract crate within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+    contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
 }
 ```

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -56,8 +56,8 @@ type Standard {
 }
 
 type BuildInfo {
-    build_environment: string, // reference to a reproducible build environment docker image, e.g., "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
+    build_environment: string, // reference to a reproducible build environment docker image, e.g., "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420" or "ipfs://<ipfs-hash>".
     contract_path: string|null, // relative path to contract crate within the source code, e.g., "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags, e.g., ["cargo", "near", "build", "--no-abi"].
 }
@@ -68,6 +68,16 @@ In order to view this information, contracts must include a getter which will re
 ```ts
 function contract_source_metadata(): ContractSourceMetadata {}
 ```
+
+### Ensuring WASM Reproducibility
+
+#### Build Environment Docker Image
+
+When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
+
+#### Cargo.lock
+
+It is important to have `Cargo.lock` inside the source code snapshot to ensure reproducibility. Example: https://github.com/near/core-contracts.
 
 ## Reference Implementation
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -55,7 +55,7 @@ type Standard {
     version: string, // semantic version number of the Standard e.g. "1.0.0"
 }
 
-type BuildDetails {
+type BuildInfo {
 	env_image: EnvImage, // reference to a reproducible build environment image, e.g. "{tag: "sourcescan/cargo-near:0.6.0", digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"}"
 	contract_path: string|null // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
 	build_command: string[] // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -1,14 +1,14 @@
 ---
 NEP: 330
 Title: Source Metadata
-Author: Ben Kurrek <ben.kurrek@near.org>, Osman Abdelnasir <osman@near.org>
+Author: Ben Kurrek <ben.kurrek@near.org>, Osman Abdelnasir <osman@near.org>, Andrey Gruzdev <@canvi>
 DiscussionsTo: https://github.com/near/NEPs/discussions/329
 Status: Approved
 Type: Standards Track
 Category: Contract
-Version: 1.1.0
+Version: 1.2.0
 Created: 27-Feb-2022
-Updated: 13-Jan-2023
+Updated: 19-Feb-2023
 ---
 
 ## Summary
@@ -214,6 +214,13 @@ The extension NEP-351 that added Contract Metadata to this NEP-330 was approved 
 | 2 | NEP-330 and NEP-351 should be included in the list of the supported NEPs | There seems to be a general agreement that it is a good default, so NEP was updated | Resolved |
 | 3 | JSON Event could be beneficial, so tooling can react to the changes in the supported standards | It is outside the scope of this NEP. Also, list of supported standards only changes with contract re-deployment, so tooling can track DEPLOY_CODE events and check the list of supported standards when new code is deployed | Won’t fix |
 
+### 1.2.0 - Build Details Extension
+
+The NEP extension adds build details to the contract metadata, containing necessary information about how the contract was built. This makes it possible for others to reproduce the same WASM of this contract. The idea first appeared in the [cargo-near SourceScan integration thread](https://github.com/near/cargo-near/issues/131).
+
+#### Benefits
+
+- This NEP extension gives developers the capability to save all the required build details, making it possible to reproduce the same WASM code in the future. This ensures greater consistency in contracts and the ability to verify source code. With the assistance of tools like SourceScan and cargo-near, the development process on NEAR becomes significantly easier
 
 ## Copyright
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -107,7 +107,7 @@ type ContractSourceMetadata = {
 
 ```
 
-Calling the view function `contract_metadata`, the contract would return:
+Calling the view function `contract_source_metadata`, the contract would return:
 
 ```bash
 {

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -56,7 +56,7 @@ type Standard {
 }
 
 type BuildInfo {
-    build_environment: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+    build_environment: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
     contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -149,7 +149,7 @@ pub struct Contract {
     pub contract_metadata: ContractSourceMetadata
 }
 
-/// Standard structure
+/// NEP supported by the contract.
 pub struct Standard {
     pub standard: String,
     pub version: String

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -37,7 +37,7 @@ Successful implementations of this standard will introduce a new  (`ContractSour
 
 The metadata will include optional fields:
 
-- `version`: a string that references the specific commit hash or version of the code currently deployed on-chain. If the link is to a GitHub repo URL, this is crucial, as it is needed to make the contract reproducible.
+- `version`: a string that references the specific commit ID or a tag of the code currently deployed on-chain. Examples: `"v0.8.1"`, `"a80bc29"`.
 - `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 - `build_details`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -57,7 +57,7 @@ type Standard {
 
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g., "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
     contract_path: string|null, // relative path to contract crate within the source code, e.g., "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags, e.g., ["cargo", "near", "build", "--no-abi"].
 }

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -38,7 +38,7 @@ Successful implementations of this standard will introduce a new  (`ContractSour
 The metadata will include optional fields:
 
 - `version`: a string that references the specific commit ID or a tag of the code currently deployed on-chain. Examples: `"v0.8.1"`, `"a80bc29"`.
-- `link`: a string that references the link to the open-source code. This can be anything such as Github or a CID to somewhere on IPFS.
+- `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: https://github.com/near/near-cli-rs/releases/tag/v0.8.1, an IPFS CID.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 - `build_details`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -58,7 +58,7 @@ type Standard {
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
-    contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+    contract_path: string|null, // relative path to contract crate within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
 }
 ```

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -57,7 +57,7 @@ type Standard {
 
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
+    source_code_snapshot: string, // reference to the source code snapshot used to build the contract, e.g., "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
     contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "--no-abi"].
 }

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -45,7 +45,7 @@ The metadata will include optional fields:
 ```ts
 type ContractSourceMetadata = {
     version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. https://"github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c"
+    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
     standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
@@ -71,30 +71,22 @@ function contract_source_metadata(): ContractSourceMetadata {}
 
 ## Reference Implementation
 
-As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment docker image `sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
+As an example, consider a contract located at the root path of the repository, which was deployed using the `cargo near deploy --no-abi` and environment docker image `sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471`. Its latest commit hash is `9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420`, and its open-source code can be found at `https://github.com/near/cargo-near-new-project-template`. This contract would then include a struct with the following fields:
 
 ```ts
 type ContractSourceMetadata = {
     version: "1.0.0",
-    link: "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c",
+    link: "https://github.com/near/cargo-near-new-project-template/commit/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
     standards: [
         {
             standard: "nep330",
             version: "1.1.0"
-        },
-        {
-            standard: "nep171",
-            version: "1.0.0"
-        },
-        {
-            standard: "nep177",
-            version: "2.0.0"
         }
     ],
     build_info: {
         build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-        source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
-        contract_path: "nft-contract",
+        source_code_snapshot: "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+        contract_path: ".",
         build_command: ["cargo", "near", "deploy", "--no-abi"]
     }
 }
@@ -106,25 +98,17 @@ Calling the view function `contract_source_metadata`, the contract would return:
 ```bash
 {
     version: "1.0.0"
-    link: "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c",
+    link: "https://github.com/near/cargo-near-new-project-template/commit/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
     standards: [
         {
             standard: "nep330", 
             version: "1.1.0"
-        },
-        {
-            standard: "nep171", 
-            version: "1.0.0"
-        },
-        {
-            standard: "nep177", 
-            version: "2.0.0"
         }
     ],
     build_info: {
         build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-        source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
-        contract_path: "nft-contract",
+        source_code_snapshot: "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+        contract_path: ".",
         build_command: ["cargo", "near", "deploy", "--no-abi"]
     }
 }

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -44,22 +44,22 @@ The metadata will include optional fields:
 
 ```ts
 type ContractSourceMetadata = {
-    version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
-    standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+    version: string|null, // optional, commit hash being used for the currently deployed WASM. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
+    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS, e.g., "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
+    standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed WASM, e.g., [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
 
 type Standard {
-    standard: string, // standard name e.g. "nep141"
-    version: string, // semantic version number of the Standard e.g. "1.0.0"
+    standard: string, // standard name, e.g., "nep141"
+    version: string, // semantic version number of the Standard, e.g., "1.0.0"
 }
 
 type BuildInfo {
-    build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
-    contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
-    build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "--no-abi"].
+    build_environment: string, // reference to a reproducible build environment docker image, e.g., "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
+    contract_path: string|null, // relative path to contract crate within the source code, e.g., "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
+    build_command: string[], // the exact command that was used to build the contract, with all the flags, e.g., ["cargo", "near", "build", "--no-abi"].
 }
 ```
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -147,8 +147,8 @@ pub struct Standard {
     pub version: String
 }
 
-/// BuildDetails structure
-pub struct BuildDetails { 
+/// BuildInfo structure
+pub struct BuildInfo { 
     pub build_environment: String,
     pub source_code_snapshot: String,
     pub contract_path: Option<String>, 
@@ -160,7 +160,7 @@ pub struct ContractSourceMetadata {
     pub version: Option<String>,
     pub link: Option<String>,
     pub standards: Option<Vec<Standard>>,
-    pub build_info: Option<BuildDetails>,
+    pub build_info: Option<BuildInfo>,
 }
 
 /// Minimum Viable Interface

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -38,14 +38,14 @@ Successful implementations of this standard will introduce a new  (`ContractSour
 The metadata will include optional fields:
 
 - `version`: a string that references the specific commit ID or a tag of the code currently deployed on-chain. Examples: `"v0.8.1"`, `"a80bc29"`.
-- `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: https://github.com/near/near-cli-rs/releases/tag/v0.8.1, an IPFS CID.
+- `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: "https://github.com/near/near-cli-rs/releases/tag/v0.8.1", "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c" or an IPFS CID.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 - `build_info`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
 
 ```ts
 type ContractSourceMetadata = {
     version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
+    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. https://"github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c"
     standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
@@ -76,7 +76,7 @@ As an example, consider an NFT contract located at the relative path `nft-contra
 ```ts
 type ContractSourceMetadata = {
     version: "1.0.0",
-    link: "https://github.com/near-examples/nft-tutorial",
+    link: "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c",
     standards: [
         {
             standard: "nep330",
@@ -106,7 +106,7 @@ Calling the view function `contract_source_metadata`, the contract would return:
 ```bash
 {
     version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-    link: "https://github.com/near-examples/nft-tutorial",
+    link: "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c",
     standards: [
         {
             standard: "nep330", 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -151,8 +151,8 @@ pub struct Standard {
 pub struct BuildDetails { 
     pub build_environment: String,
     pub source_code_snapshot: String,
-	pub contract_path: Option<String>, 
-	pub build_command: Vec<String>, 
+    pub contract_path: Option<String>, 
+    pub build_command: Vec<String>, 
 }
 
 /// Contract metadata structure

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -40,7 +40,7 @@ The metadata will include optional fields:
 - `version`: a string that references the specific commit ID or a tag of the code currently deployed on-chain. Examples: `"v0.8.1"`, `"a80bc29"`.
 - `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: https://github.com/near/near-cli-rs/releases/tag/v0.8.1, an IPFS CID.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
-- `build_details`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
+- `build_info`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
 
 ```ts
 type ContractSourceMetadata = {
@@ -56,14 +56,10 @@ type Standard {
 }
 
 type BuildInfo {
-	env_image: EnvImage, // reference to a reproducible build environment image, e.g. "{tag: "sourcescan/cargo-near:0.6.0", digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"}"
-	contract_path: string|null // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
-	build_command: string[] // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
-}
-
-type EnvImage {
-	tag: string // tag of the image e.g. "sourcescan/cargo-near:0.6.0"
-	digest: string // a sha256 hash unique, immutable identifier for a container image, used to verify that the image under the same tag has not changed e.g. "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
+  build_environment_ref: string, // reference to a reproducible build environment image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+  source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
+	contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+	build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
 }
 ```
 
@@ -75,11 +71,11 @@ function contract_source_metadata(): ContractSourceMetadata {}
 
 ## Reference Implementation
 
-As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment image `sourcescan/cargo-near:0.6.0`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
+As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment image `sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
 
 ```ts
 type ContractSourceMetadata = {
-  version: "39f2d2646f2f60e18ab53337501370dc02a5661c",
+  version: "1.0.0",
   link: "https://github.com/near-examples/nft-tutorial",
   standards: [
     {
@@ -95,11 +91,9 @@ type ContractSourceMetadata = {
       version: "2.0.0"
     }
   ],
-  build_details: {
-    env_image: {
-      tag: "sourcescan/cargo-near:0.6.0",
-      digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
-    },
+  build_info: {
+    build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+    source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
     contract_path: "nft-contract",
     build_command: ["cargo", "near", "deploy", "--no-abi"]
   }
@@ -127,11 +121,9 @@ Calling the view function `contract_source_metadata`, the contract would return:
             version: "2.0.0"
         }
     ],
-    build_details: {
-	    env_image: {
-	      tag: "sourcescan/cargo-near:0.6.0",
-	      digest: "sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471"
-	    },
+    build_info: {
+	    build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+      source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
 	    contract_path: "nft-contract",
 	    build_command: ["cargo", "near", "deploy", "--no-abi"]
 	}
@@ -155,15 +147,10 @@ pub struct Standard {
     pub version: String
 }
 
-/// EnvImage structure
-pub struct EnvImage { 
-	pub tag: String, 
-	pub digest: String, 
-}
-
 /// BuildDetails structure
 pub struct BuildDetails { 
-	pub env_image: EnvImage, 
+	pub build_environment_ref: String,
+  pub source_code_snapshot: String,
 	pub contract_path: Option<String>, 
 	pub build_command: Vec<String>, 
 }
@@ -173,7 +160,7 @@ pub struct ContractSourceMetadata {
     pub version: Option<String>,
     pub link: Option<String>,
     pub standards: Option<Vec<Standard>>,
-    pub build_details: Option<BuildDetails>,
+    pub build_info: Option<BuildDetails>,
 }
 
 /// Minimum Viable Interface

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -1,7 +1,7 @@
 ---
 NEP: 330
 Title: Source Metadata
-Author: Ben Kurrek <ben.kurrek@near.org>, Osman Abdelnasir <osman@near.org>, Andrey Gruzdev <@canvi>
+Author: Ben Kurrek <ben.kurrek@near.org>, Osman Abdelnasir <osman@near.org>, Andrey Gruzdev <@canvi>, Alexey Zenin <@alexthebuildr>
 DiscussionsTo: https://github.com/near/NEPs/discussions/329
 Status: Approved
 Type: Standards Track
@@ -13,13 +13,17 @@ Updated: 19-Feb-2023
 
 ## Summary
 
-The contract source metadata is a standard interface that allows auditing and viewing source code for a deployed smart contract. Implementation of this standard is purely optional but is recommended for developers whose contracts are open source.
+The contract source metadata represents a standardized interface designed to facilitate the auditing and inspection of source code associated with a deployed smart contract. Adoption of this standard remains discretionary; however, it is strongly advocated for developers who maintain an open-source approach to their contracts. This initiative promotes greater accountability and transparency within the ecosystem, encouraging best practices in contract development and deployment.
 
 ## Motivation
 
-There is no trivial way of finding the source code or author of a deployed smart contract. Having a standard that outlines how to view the source code of an arbitrary smart contract creates an environment of openness and collaboration.
+The incorporation of metadata facilitates the discovery and validation of deployed source code, thereby significantly reducing the requisite level of trust during code integration or interaction processes.
 
-Additionally, we would like for wallets and dApps to be able to parse this information and determine which methods they are able to call and render UIs that provide that functionality.
+The absence of an accepted protocol for identifying the source code or originator of a deployed smart contract presents a challenge. Establishing a standardized framework for accessing the source code of any given smart contract would foster a culture of transparency and collaborative engagement.
+
+Moreover, the current landscape does not offer a straightforward mechanism to verify the authenticity of a smart contract's deployed source code against its deployed version. To address this issue, it is imperative that metadata includes specific details that enable contract verification through reproducible builds.
+
+Furthermore, it is desirable for users and dApps to possess the capability to interpret this metadata, thereby identifying executable methods and generating UIs that facilitate such functionalities. This also extends to acquiring comprehensive insights into potential future modifications by the contract or its developers, enhancing overall system transparency and user trust.
 
 The initial discussion can be found [here](https://github.com/near/NEPs/discussions/329).
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -75,28 +75,28 @@ As an example, consider an NFT contract located at the relative path `nft-contra
 
 ```ts
 type ContractSourceMetadata = {
-  version: "1.0.0",
-  link: "https://github.com/near-examples/nft-tutorial",
-  standards: [
-    {
-      standard: "nep330",
-      version: "1.1.0"
-    },
-    {
-      standard: "nep171",
-      version: "1.0.0"
-    },
-    {
-      standard: "nep177",
-      version: "2.0.0"
+    version: "1.0.0",
+    link: "https://github.com/near-examples/nft-tutorial",
+    standards: [
+        {
+            standard: "nep330",
+            version: "1.1.0"
+        },
+        {
+            standard: "nep171",
+            version: "1.0.0"
+        },
+        {
+            standard: "nep177",
+            version: "2.0.0"
+        }
+    ],
+    build_info: {
+        build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
+        contract_path: "nft-contract",
+        build_command: ["cargo", "near", "deploy", "--no-abi"]
     }
-  ],
-  build_info: {
-    build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-    source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
-    contract_path: "nft-contract",
-    build_command: ["cargo", "near", "deploy", "--no-abi"]
-  }
 }
 
 ```
@@ -122,11 +122,11 @@ Calling the view function `contract_source_metadata`, the contract would return:
         }
     ],
     build_info: {
-	    build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-      source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
-	    contract_path: "nft-contract",
-	    build_command: ["cargo", "near", "deploy", "--no-abi"]
-	}
+	      build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
+	      contract_path: "nft-contract",
+	      build_command: ["cargo", "near", "deploy", "--no-abi"]
+	  }
 }
 ```
 
@@ -149,10 +149,10 @@ pub struct Standard {
 
 /// BuildDetails structure
 pub struct BuildDetails { 
-	pub build_environment_ref: String,
-  pub source_code_snapshot: String,
-	pub contract_path: Option<String>, 
-	pub build_command: Vec<String>, 
+	  pub build_environment_ref: String,
+    pub source_code_snapshot: String,
+	  pub contract_path: Option<String>, 
+	  pub build_command: Vec<String>, 
 }
 
 /// Contract metadata structure

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -57,7 +57,7 @@ type Standard {
 
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
     contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "--no-abi"].
 }

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -105,7 +105,7 @@ Calling the view function `contract_source_metadata`, the contract would return:
 
 ```bash
 {
-    version: "39f2d2646f2f60e18ab53337501370dc02a5661c"
+    version: "1.0.0"
     link: "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c",
     standards: [
         {

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -92,7 +92,7 @@ type ContractSourceMetadata = {
         }
     ],
     build_info: {
-        build_environment: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
         source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
         contract_path: "nft-contract",
         build_command: ["cargo", "near", "deploy", "--no-abi"]

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -44,10 +44,10 @@ The metadata will include optional fields:
 
 ```ts
 type ContractSourceMetadata = {
-  version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-  link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
-  standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
-  build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
+    version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
+    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS.
+    standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+    build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
 
 type Standard {
@@ -56,10 +56,10 @@ type Standard {
 }
 
 type BuildInfo {
-  build_environment_ref: string, // reference to a reproducible build environment image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
-  source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
-	contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
-	build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
+    build_environment_ref: string, // reference to a reproducible build environment image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
+	  contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
+	  build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
 }
 ```
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -56,7 +56,7 @@ type Standard {
 }
 
 type BuildInfo {
-    build_environment_ref: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+    build_environment: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
     contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
@@ -92,7 +92,7 @@ type ContractSourceMetadata = {
         }
     ],
     build_info: {
-        build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        build_environment: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
         source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
         contract_path: "nft-contract",
         build_command: ["cargo", "near", "deploy", "--no-abi"]
@@ -122,7 +122,7 @@ Calling the view function `contract_source_metadata`, the contract would return:
         }
     ],
     build_info: {
-        build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        build_environment: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
         source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
         contract_path: "nft-contract",
         build_command: ["cargo", "near", "deploy", "--no-abi"]
@@ -149,10 +149,10 @@ pub struct Standard {
 
 /// BuildDetails structure
 pub struct BuildDetails { 
-	  pub build_environment_ref: String,
+    pub build_environment: String,
     pub source_code_snapshot: String,
-	  pub contract_path: Option<String>, 
-	  pub build_command: Vec<String>, 
+	pub contract_path: Option<String>, 
+	pub build_command: Vec<String>, 
 }
 
 /// Contract metadata structure

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -59,7 +59,7 @@ type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
     contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
-    build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
+    build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "--no-abi"].
 }
 ```
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -19,7 +19,7 @@ The contract source metadata represents a standardized interface designed to fac
 
 The incorporation of metadata facilitates the discovery and validation of deployed source code, thereby significantly reducing the requisite level of trust during code integration or interaction processes.
 
-The absence of an accepted protocol for identifying the source code or originator of a deployed smart contract presents a challenge. Establishing a standardized framework for accessing the source code of any given smart contract would foster a culture of transparency and collaborative engagement.
+The absence of an accepted protocol for identifying the source code or author contact details of a deployed smart contract presents a challenge. Establishing a standardized framework for accessing the source code of any given smart contract would foster a culture of transparency and collaborative engagement.
 
 Moreover, the current landscape does not offer a straightforward mechanism to verify the authenticity of a smart contract's deployed source code against its deployed version. To address this issue, it is imperative that metadata includes specific details that enable contract verification through reproducible builds.
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -56,7 +56,7 @@ type Standard {
 }
 
 type BuildInfo {
-    build_environment_ref: string, // reference to a reproducible build environment image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
+    build_environment_ref: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
 	  contract_path: string|null, // relative path to contract folder within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
 	  build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].
@@ -71,7 +71,7 @@ function contract_source_metadata(): ContractSourceMetadata {}
 
 ## Reference Implementation
 
-As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment image `sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
+As an example, consider an NFT contract located at the relative path `nft-contract`, which was deployed using the `cargo near deploy --no-abi` environment docker image `sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471`. Its latest commit hash is `39f2d2646f2f60e18ab53337501370dc02a5661c`, and its open-source code can be found at `https://github.com/near-examples/nft-tutorial`. This contract would then include a struct with the following fields:
 
 ```ts
 type ContractSourceMetadata = {

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -38,14 +38,14 @@ Successful implementations of this standard will introduce a new  (`ContractSour
 The metadata will include optional fields:
 
 - `version`: a string that references the specific commit ID or a tag of the code currently deployed on-chain. Examples: `"v0.8.1"`, `"a80bc29"`.
-- `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: "https://github.com/near/near-cli-rs/releases/tag/v0.8.1", "https://github.com/near-examples/nft-tutorial/tree/39f2d2646f2f60e18ab53337501370dc02a5661c" or an IPFS CID.
+- `link`: an URL to the currently deployed code. It must include version or a tag if using a GitHub or a GitLab link. Examples: "https://github.com/near/near-cli-rs/releases/tag/v0.8.1", "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420" or an IPFS CID.
 - `standards`: a list of objects (see type definition below) that enumerates the NEPs supported by the contract. If this extension is supported, it is advised to also include NEP-330 version 1.1.0 in the list (`{standard: "nep330", version: "1.1.0"}`).
 - `build_info`: a build details object (see type definition below) that contains all the necessary information about how the contract was built, making it possible for others to reproduce the same WASM of this contract.
 
 ```ts
 type ContractSourceMetadata = {
     version: string|null, // optional, commit hash being used for the currently deployed wasm. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
-    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
+    link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS. e.g. "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
     standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed wasm e.g. [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
@@ -76,7 +76,7 @@ As an example, consider a contract located at the root path of the repository, w
 ```ts
 type ContractSourceMetadata = {
     version: "1.0.0",
-    link: "https://github.com/near/cargo-near-new-project-template/commit/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+    link: "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
     standards: [
         {
             standard: "nep330",
@@ -98,7 +98,7 @@ Calling the view function `contract_source_metadata`, the contract would return:
 ```bash
 {
     version: "1.0.0"
-    link: "https://github.com/near/cargo-near-new-project-template/commit/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+    link: "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
     standards: [
         {
             standard: "nep330", 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -75,6 +75,12 @@ function contract_source_metadata(): ContractSourceMetadata {}
 
 When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
 
+### Paths Inside Docker Image
+
+During the build, paths from the source of the build as well as the location of the cargo registry could be saved into WASM, which affects reproducibility. Therefore, we need to ensure that everyone uses the same paths inside the Docker image. We propose using the following paths:
+- `/home/near/code` - Mounting volume from the host system containing the source code.
+- `/home/near/.cargo` - Cargo registry.
+
 #### Cargo.lock
 
 It is important to have `Cargo.lock` inside the source code snapshot to ensure reproducibility. Example: https://github.com/near/core-contracts.

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -57,7 +57,7 @@ type Standard {
 
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
-    source_code_snapshot: string, // reference to the source code snapshot used to build the contract, e.g., "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
+    source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>". It is important to have Cargo.lock inside the source code snapshot to ensure reproducibility.
     contract_path: string|null, // relative path to contract crate within the source code e.g. "contracts/contract-one". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "--no-abi"].
 }

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -56,7 +56,7 @@ type Standard {
 }
 
 type BuildInfo {
-    build_environment: string, // reference to a reproducible build environment docker image, e.g. "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
+    build_environment: string, // reference to a reproducible build environment docker image, e.g. "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment. When using a Docker image as a reference, it's important to specify the digest of the image to ensure reproducibility, since a tag could be reassigned to a different image.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g. "git+https://github.com/near-DevHub/neardevhub-contract.git#335e89edec95d56a4744e7160c3fd590e41ec38e" or "ipfs://<ipfs-hash>"
     contract_path: string|null, // relative path to contract crate within the source code e.g. "src/contract". Often, it is the root of the repository, so can be omitted. 
     build_command: string[], // the exact command that was used to build the contract, with all the flags e.g. ["cargo", "near", "build", "no-abi"].

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -122,7 +122,7 @@ Calling the view function `contract_source_metadata`, the contract would return:
         }
     ],
     build_info: {
-        build_environment: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
         source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
         contract_path: "nft-contract",
         build_command: ["cargo", "near", "deploy", "--no-abi"]

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -122,11 +122,11 @@ Calling the view function `contract_source_metadata`, the contract would return:
         }
     ],
     build_info: {
-	      build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        build_environment_ref: "sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
         source_code_snapshot: "git+https://github.com/near-examples/nft-tutorial.git#39f2d2646f2f60e18ab53337501370dc02a5661c",
-	      contract_path: "nft-contract",
-	      build_command: ["cargo", "near", "deploy", "--no-abi"]
-	  }
+        contract_path: "nft-contract",
+        build_command: ["cargo", "near", "deploy", "--no-abi"]
+    }
 }
 ```
 

--- a/specs/ChainSpec/SelectingBlockProducers.md
+++ b/specs/ChainSpec/SelectingBlockProducers.md
@@ -25,6 +25,7 @@ block producers to be the one responsible for producing the chunk/block at each 
 shard.
 
 There are several desiderata for these algorithms:
+
 * Larger stakes should be preferred (more staked tokens means more security)
 * The frequency with which a given participant is selected to produce a particular chunk/block is
   proportional to that participant's stake
@@ -71,6 +72,7 @@ In mainnet and testnet, `epoch_length` is set to `43200`. Let $\text{PROBABILITY
 we obtain, $s_\text{min} / S = 160/1000,000$.
 
 ## Algorithm for selecting block and chunk producers
+
 A potential validator cannot specify whether they want to become a block producer or a chunk-only producer. 
 There is only one type of proposal. The same algorithm is used for selecting block producers and chunk producers, 
 but with different thresholds. The threshold for becoming block producers is higher, so if a node is selected as a block 
@@ -78,7 +80,9 @@ producer, it will also be a chunk producer, but not the other way around. Valida
 but not block producers are chunk-only producers.
 
 ### select_validators
+
 ### Input
+
 * `max_num_validators: u16` max number of validators to be selected
 * `min_stake_fraction: Ratio<u128>` minimum stake ratio for selected validator
 * `validator_proposals: Vec<ValidatorStake>` (proposed stakes for the next epoch from nodes sending
@@ -110,7 +114,9 @@ return (validators, validator_sampler)
 ```
 
 ### Algorithm for selecting block producers
+
 ### Input
+
 * `MAX_NUM_BP: u16` Max number of block producers, see Assumptions
 * `min_stake_fraction: Ratio<u128>` $s_\text{min} / S$, see Assumptions
 * `validator_proposals: Vec<ValidatorStake>` (proposed stakes for the next epoch from nodes sending
@@ -121,7 +127,9 @@ select_validators(MAX_NUM_BP, min_stake_fraction, validator_proposals)
 ```
 
 ### Algorithm for selecting chunk producers
+
 ### Input
+
 * `MAX_NUM_CP: u16` max number of chunk producers, see Assumptions`
 * `min_stake_fraction: Ratio<u128>` $s_\text{min} / S$, see Assumptions
 * `num_shards: u64` number of shards
@@ -137,6 +145,7 @@ them in a way that the total stake in each shard is distributed as evenly as pos
 So the total stake in each shard will be roughly be `total_stake_all_chunk_producers / num_shards`.
 
 ## Algorithm for assigning chunk producers to shards
+
 Note that block producers are a subset of chunk producers, so this algorithm will also assign block producers
 to shards. This also means that a block producer may only be assigned to a subset of shards. For the security of 
 the protocol, all block producers must track all shards, even if they are not assigned to produce chunks for all shards. 
@@ -181,6 +190,7 @@ the same algorithm works to assign chunk producers to shards; it is only a matte
 variables referencing "block producers" to reference "chunk producers" instead.
 
 ## Algorithm for sampling validators proportional to stake
+
 We sample validators with probability proportional to their stake using the following data structure.
 * `weighted_sampler: WeightedIndex`
   - Allow $O(1)$ sampling

--- a/specs/ChainSpec/SelectingBlockProducers.md
+++ b/specs/ChainSpec/SelectingBlockProducers.md
@@ -25,7 +25,6 @@ block producers to be the one responsible for producing the chunk/block at each 
 shard.
 
 There are several desiderata for these algorithms:
-
 * Larger stakes should be preferred (more staked tokens means more security)
 * The frequency with which a given participant is selected to produce a particular chunk/block is
   proportional to that participant's stake
@@ -72,7 +71,6 @@ In mainnet and testnet, `epoch_length` is set to `43200`. Let $\text{PROBABILITY
 we obtain, $s_\text{min} / S = 160/1000,000$.
 
 ## Algorithm for selecting block and chunk producers
-
 A potential validator cannot specify whether they want to become a block producer or a chunk-only producer. 
 There is only one type of proposal. The same algorithm is used for selecting block producers and chunk producers, 
 but with different thresholds. The threshold for becoming block producers is higher, so if a node is selected as a block 
@@ -80,9 +78,7 @@ producer, it will also be a chunk producer, but not the other way around. Valida
 but not block producers are chunk-only producers.
 
 ### select_validators
-
 ### Input
-
 * `max_num_validators: u16` max number of validators to be selected
 * `min_stake_fraction: Ratio<u128>` minimum stake ratio for selected validator
 * `validator_proposals: Vec<ValidatorStake>` (proposed stakes for the next epoch from nodes sending
@@ -114,9 +110,7 @@ return (validators, validator_sampler)
 ```
 
 ### Algorithm for selecting block producers
-
 ### Input
-
 * `MAX_NUM_BP: u16` Max number of block producers, see Assumptions
 * `min_stake_fraction: Ratio<u128>` $s_\text{min} / S$, see Assumptions
 * `validator_proposals: Vec<ValidatorStake>` (proposed stakes for the next epoch from nodes sending
@@ -127,9 +121,7 @@ select_validators(MAX_NUM_BP, min_stake_fraction, validator_proposals)
 ```
 
 ### Algorithm for selecting chunk producers
-
 ### Input
-
 * `MAX_NUM_CP: u16` max number of chunk producers, see Assumptions`
 * `min_stake_fraction: Ratio<u128>` $s_\text{min} / S$, see Assumptions
 * `num_shards: u64` number of shards
@@ -145,7 +137,6 @@ them in a way that the total stake in each shard is distributed as evenly as pos
 So the total stake in each shard will be roughly be `total_stake_all_chunk_producers / num_shards`.
 
 ## Algorithm for assigning chunk producers to shards
-
 Note that block producers are a subset of chunk producers, so this algorithm will also assign block producers
 to shards. This also means that a block producer may only be assigned to a subset of shards. For the security of 
 the protocol, all block producers must track all shards, even if they are not assigned to produce chunks for all shards. 
@@ -190,12 +181,11 @@ the same algorithm works to assign chunk producers to shards; it is only a matte
 variables referencing "block producers" to reference "chunk producers" instead.
 
 ## Algorithm for sampling validators proportional to stake
-
 We sample validators with probability proportional to their stake using the following data structure.
 * `weighted_sampler: WeightedIndex`
   - Allow $O(1)$ sampling
   - This structure will be based on the
-    [WeightedIndex](https://rust-random.github.io/rand/rand/distributions/struct.WeightedIndex.html)
+    [WeightedIndex](https://rust-random.github.io/rand/rand/distributions/weighted/alias_method/struct.WeightedIndex.html)
     implementation (see a description of [Vose's Alias
     Method](https://en.wikipedia.org/wiki/Alias_method) for details)
 

--- a/specs/ChainSpec/SelectingBlockProducers.md
+++ b/specs/ChainSpec/SelectingBlockProducers.md
@@ -185,7 +185,7 @@ We sample validators with probability proportional to their stake using the foll
 * `weighted_sampler: WeightedIndex`
   - Allow $O(1)$ sampling
   - This structure will be based on the
-    [WeightedIndex](https://rust-random.github.io/rand/rand/distributions/weighted/alias_method/struct.WeightedIndex.html)
+    [WeightedIndex](https://rust-random.github.io/rand/rand/distributions/struct.WeightedIndex.html)
     implementation (see a description of [Vose's Alias
     Method](https://en.wikipedia.org/wiki/Alias_method) for details)
 


### PR DESCRIPTION
## NEP-330: Source Metadata
## 1.2.0 - Build Details Extension

### Overview
This update introduces build details to the contract metadata, containing necessary information about how the contract was built. This makes it possible for others to reproduce the same WASM of this contract. The idea first appeared in the [cargo-near SourceScan integration thread](https://github.com/near/cargo-near/issues/131).

### Benefits

This NEP extension gives developers the capability to save all the required build details, making it possible to reproduce the same WASM code in the future. This ensures greater consistency in contracts and the ability to verify source code. With the assistance of tools like SourceScan and cargo-near, the development process on NEAR becomes significantly easier.
