### PR TITLE
Fix: links to examples for NEP413

### DIFF
--- a/neps/nep-0413.md
+++ b/neps/nep-0413.md
@@ -159,7 +159,7 @@ Non-web Wallets, such as [Ledger](https://www.ledger.com) can directly return th
 
 ## References
 
-A full example on how to implement the `signMessage` method can be [found here](https://github.com/gagdiez/near-login/blob/main/tests/authentication/auth.ava.ts#L27-#L65).
+A full example on how to implement the `signMessage` method can be [found here](https://github.com/gagdiez/near-login/blob/1650e25080ab2e8a8c508638a9ba9e9732e76036/server/tests/wallet.ts#L60-L77).
 
 ## Drawbacks
 


### PR DESCRIPTION
The links to the working example were broken, this commit fixes it