### PR TITLE
Transactions.md redirect

### DIFF
--- a/specs/DataStructures/Transaction.md
+++ b/specs/DataStructures/Transaction.md
@@ -1,1 +1,3 @@
 # Transaction
+
+See [Transactions](../ChainSpec/Transactions.md), in the [Chain Specification](../ChainSpec) section.

--- a/specs/DataStructures/Transaction.md
+++ b/specs/DataStructures/Transaction.md
@@ -1,3 +1,3 @@
 # Transaction
 
-See [Transactions](../ChainSpec/Transactions.md), in the [Chain Specification](../ChainSpec) section.
+See [Transactions](../RuntimeSpec/Transactions.md) documentation in the [Runtime Specification](../RuntimeSpec) section.


### PR DESCRIPTION
https://nomicon.io/DataStructures/Transaction is blank.  I'm adding a link to the Transactions spec page.

We also could delete this page but I'm choosing not to because:
1. There might be links to this page that would break.
2. Many chains consider a Transaction to be a core data structure - so this blank page is the first place I looked to learn about the NEAR tx format.  I think having a link here that points people in the right direction could be nice for people new to NEAR.