### PR TITLE
Update documentation about combined_transactions_size_limit

### DIFF
--- a/neps/nep-0509.md
+++ b/neps/nep-0509.md
@@ -400,7 +400,7 @@ The limits are:
 * `max_receipt_size - 4 MiB`:
     * All receipts must be below 4 MiB, otherwise they'll be considered invalid and rejected.
     * Previously there was no limit on receipt size. Set to 4MiB, might be reduced to 1.5MiB in the future to match the transaction limit.
-* `combined_transactions_size_limit - 2 MiB`
+* `combined_transactions_size_limit - 4 MiB`
     * Hard limit on total size of transactions from this and previous chunk. `ChunkStateWitness` contains transactions from two chunks, this limit applies to the sum of their sizes.
 * `new_transactions_validation_state_size_soft_limit - 500 KiB`
     * Validating new transactions generates storage proof (recorded trie nodes), which has to be limited. Once transaction validation generates more storage proof than this limit, the chunk producer stops adding new transactions to the chunk.
@@ -418,7 +418,7 @@ The limits are:
     * A receiving shard will receive receipts from `num_shards - 1` shards using the usual limit and one shard using the big limit.
     * The "allowed shard" is the same shard as in cross-shard congestion control. It's chosen in a round-robin fashion, at height 1 the special shard is 0, at height 2 it's 1 and so on.
 
-In total that gives 2 MiB + 500 KiB + 7MB + 5*100 KiB + 4.5 MiB ~= 14 MiB of maximum witness size
+In total that gives 4 MiB + 500 KiB + 7MB + 5*100 KiB + 4.5 MiB ~= 16 MiB of maximum witness size. Possibly a little more on missing chunks.
 
 ### New limits breaking contracts
 


### PR DESCRIPTION
In https://github.com/near/nearcore/pull/11582 we're increasing `combined_transactions_size_limit`, so let's update the NEP to match the implementation.