### PR TITLE
fix: markdownlint, linkchecker issues

### DIFF
--- a/specs/ChainSpec/SelectingBlockProducers.md
+++ b/specs/ChainSpec/SelectingBlockProducers.md
@@ -113,7 +113,7 @@ validator_sampler = WeightedIndex([v.stake for v in validators])
 return (validators, validator_sampler)
 ```
 
-### Algorithm for selecting block producers
+## Algorithm for selecting block producers
 
 ### Input
 
@@ -126,7 +126,7 @@ return (validators, validator_sampler)
 select_validators(MAX_NUM_BP, min_stake_fraction, validator_proposals)
 ```
 
-### Algorithm for selecting chunk producers
+## Algorithm for selecting chunk producers
 
 ### Input
 

--- a/specs/ChainSpec/SelectingBlockProducers.md
+++ b/specs/ChainSpec/SelectingBlockProducers.md
@@ -197,7 +197,7 @@ We sample validators with probability proportional to their stake using the foll
 - `weighted_sampler: WeightedIndex`
   - Allow $O(1)$ sampling
   - This structure will be based on the
-    [WeightedIndex](https://rust-random.github.io/rand/rand/distributions/struct.WeightedIndex.html)
+    [WeightedIndex](https://docs.rs/rand/latest/rand/distributions/struct.WeightedIndex.html)
     implementation (see a description of [Vose's Alias
     Method](https://en.wikipedia.org/wiki/Alias_method) for details)
 


### PR DESCRIPTION
* Adds a missing link that's breaking the link checker 
I've verified the contents of the previous link via [wayback machine](http://web.archive.org/web/20231204231021/https://rust-random.github.io/rand/rand/distributions/struct.WeightedIndex.html)
* Fixes lint consistency error