### PR TITLE
[NEP-330]: add `output_wasm_path` field extension

### DIFF
--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -46,7 +46,7 @@ The metadata will include optional fields:
 type ContractSourceMetadata = {
     version: string|null, // optional, commit hash being used for the currently deployed WASM. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
     link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS, e.g., "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
-    standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed WASM, e.g., [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+    standards: Standard[], // standards and extensions implemented in the currently deployed WASM, e.g., [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
 
@@ -58,8 +58,9 @@ type Standard {
 type BuildInfo {
     build_environment: string, // reference to a reproducible build environment docker image, e.g., "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471" or something else pointing to the build environment.
     source_code_snapshot: string, // reference to the source code snapshot that was used to build the contract, e.g., "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420" or "ipfs://<ipfs-hash>".
-    contract_path: string|null, // relative path to contract crate within the source code, e.g., "contracts/contract-one". Often, it is the root of the repository, so can be omitted.
+    contract_path: string, // relative path to contract crate within the source code, e.g., "contracts/contract-one". Often, it is the root of the repository, so can be set to empty string.
     build_command: string[], // the exact command that was used to build the contract, with all the flags, e.g., ["cargo", "near", "build", "--no-abi"].
+    output_wasm_path: string|null, // absolute path inside build environment, where resulting `*.wasm` file was put during build
 }
 ```
 
@@ -102,9 +103,10 @@ type ContractSourceMetadata = {
     ],
     build_info: {
         build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-        source_code_snapshot: "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
-        contract_path: ".",
-        build_command: ["cargo", "near", "deploy", "--no-abi"]
+        source_code_snapshot: "git+https://github.com/near/cargo-near-new-project-template?rev=9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+        contract_path: "",
+        build_command: ["cargo", "near", "deploy", "--no-abi"],
+        output_wasm_path: "/home/near/code/target/near/cargo_near_new_project_name.wasm"
     }
 }
 
@@ -112,21 +114,22 @@ type ContractSourceMetadata = {
 
 Calling the view function `contract_source_metadata`, the contract would return:
 
-```bash
+```json
 {
-    version: "1.0.0"
-    link: "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
-    standards: [
+    "version": "1.0.0"
+    "link": "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+    "standards": [
         {
-            standard: "nep330",
-            version: "1.1.0"
+            "standard": "nep330",
+            "version": "1.3.0"
         }
     ],
-    build_info: {
-        build_environment: "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
-        source_code_snapshot: "git+https://github.com/near/cargo-near-new-project-template.git#9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
-        contract_path: ".",
-        build_command: ["cargo", "near", "deploy", "--no-abi"]
+    "build_info": {
+        "build_environment": "docker.io/sourcescan/cargo-near@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+        "source_code_snapshot": "git+https://github.com/near/cargo-near-new-project-template?rev=9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420",
+        "contract_path": "",
+        "build_command": ["cargo", "near", "deploy", "--no-abi"],
+        "output_wasm_path": "/home/near/code/target/near/cargo_near_new_project_name.wasm"
     }
 }
 ```
@@ -152,15 +155,16 @@ pub struct Standard {
 pub struct BuildInfo {
     pub build_environment: String,
     pub source_code_snapshot: String,
-    pub contract_path: Option<String>,
+    pub contract_path: String,
     pub build_command: Vec<String>,
+    pub output_wasm_path: Option<String>,
 }
 
 /// Contract metadata structure
 pub struct ContractSourceMetadata {
     pub version: Option<String>,
     pub link: Option<String>,
-    pub standards: Option<Vec<Standard>>,
+    pub standards: Vec<Standard>,
     pub build_info: Option<BuildInfo>,
 }
 
@@ -209,6 +213,16 @@ The extension NEP-351 that added Contract Metadata to this NEP-330 was approved 
 ### 1.2.0 - Build Details Extension
 
 The NEP extension adds build details to the contract metadata, containing necessary information about how the contract was built. This makes it possible for others to reproduce the same WASM of this contract. The idea first appeared in the [cargo-near SourceScan integration thread](https://github.com/near/cargo-near/issues/131).
+
+### 1.3.0 - Add `output_wasm_path` field to Build Details Extension
+
+1. This field is required in order to be able to verify build in a way, that is agnostic of 
+   specific language/toolchain the contract is implemented with.
+2. Field's type is `Option<String>` (rust semantics) which allows backward compatibility with 1.2.0 contract metadata
+   when parsing, when the field is absent.
+3. If the field is present, contract metadata is considered to be at least 1.3.0 version.
+4. Valid value for the field should be a valid unix path to a `wasm` file, being a subpath of 
+   `/home/near/code` (mentioned in [Paths Inside Docker Image](#paths-inside-docker-image)).
 
 #### Benefits
 

--- a/neps/nep-0330.md
+++ b/neps/nep-0330.md
@@ -46,7 +46,7 @@ The metadata will include optional fields:
 type ContractSourceMetadata = {
     version: string|null, // optional, commit hash being used for the currently deployed WASM. If the contract is not open-sourced, this could also be a numbering system for internal organization / tracking such as "1.0.0" and "2.1.0".
     link: string|null, // optional, link to open source code such as a Github repository or a CID to somewhere on IPFS, e.g., "https://github.com/near/cargo-near-new-project-template/tree/9c16aaff3c0fe5bda4d8ffb418c4bb2b535eb420"
-    standards: Standard[], // standards and extensions implemented in the currently deployed WASM, e.g., [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
+    standards: Standard[]|null, // optional, standards and extensions implemented in the currently deployed WASM, e.g., [{standard: "nep330", version: "1.1.0"},{standard: "nep141", version: "1.0.0"}].
     build_info: BuildInfo|null, // optional, details that are required for contract WASM reproducibility.
 }
 
@@ -164,7 +164,7 @@ pub struct BuildInfo {
 pub struct ContractSourceMetadata {
     pub version: Option<String>,
     pub link: Option<String>,
-    pub standards: Vec<Standard>,
+    pub standards: Option<Vec<Standard>>,
     pub build_info: Option<BuildInfo>,
 }
 


### PR DESCRIPTION
a working implementation according to this change is present in following prs:
1. https://github.com/near/near-sdk-rs/pull/1344 (contract sdk)
2. https://github.com/near/cargo-near/pull/323 (build tool)
3. https://github.com/near/near-verify-rs/pull/4 (lib to verify WASM reproducibility of contracts with)
4. https://github.com/near/near-verify-rs/pull/9
5. https://github.com/near/cargo-near/pull/328
6. https://github.com/near/near-verify-rs/pull/10