### PR TITLE
 doc: gas refund fee

### DIFF
--- a/specs/RuntimeSpec/Fees/Fees.md
+++ b/specs/RuntimeSpec/Fees/Fees.md
@@ -103,7 +103,7 @@ Then each `ActionReceipt` is passed to `Runtime::apply_action_receipt` where gas
   - `gas_burnt`: **send** fee for **new** `ActionReceipt` creation + complex **send** fee for `Transfer` to beneficiary account
   - `gas_used`: `gas_burnt` + **exec** fee for created `ActionReceipt` + complex **exec** fee for `Transfer`
 - all computed `ActionResult`s are merged into one, where all gas values are summed up;
-- unused gas is refunded in `generate_refund_receipts`.
+- unused gas is refunded in `generate_refund_receipts`, after subtracting the gas refund fee, see [Refunds](../Refunds.md).
 
 Inside `VMLogic`, the fees are tracked in the `GasCounter` struct. 
 The VM itself is called in the `action_function_call` inside `Runtime`. When all actions are processed, the result is returned as a `VMOutcome`, which is later merged with `ActionResult`.

--- a/specs/RuntimeSpec/Refunds.md
+++ b/specs/RuntimeSpec/Refunds.md
@@ -22,6 +22,8 @@ Deposit refunds have the following fields in the `ActionReceipt`:
 - `signer_id` is `system`
 - `signer_public_key` is ED25519 key with data equal to 32 bytes of `0`.
 
+Deposit refunds are free for the user and incur no refund fee.
+
 ## Gas Refunds
 
 Gas refunds are generated when a receipt used the amount of gas lower than the attached amount of gas.
@@ -33,7 +35,11 @@ If the receipt execution failed, the gas amount is equal to `prepaid_gas + execu
 The difference between `burnt_gas` and `used_gas` is the `used_gas` also includes the fees and the prepaid gas of
 newly generated receipts, e.g. from cross-contract calls in function calls actions.
 
-Then the gas amount is converted to tokens by multiplying by the gas price at which the original transaction was generated.
+From this unspent gas amount, the netowrk charges a gas refund fee, starting with protcol version 78. The exact fee is calculated as `max(gas_refund_penalty * unspent_gas, min_gas_refund_penalty)`. As of version 78, `gas_refund_penalty` is 5% and `min_gas_refund_penalty` 1 Tgas.
+
+Should the gas refund fee be euqal or larger than the unspent gas, no refund will be produced.
+
+If there is gas to refund left, the gas amount is converted to tokens by multiplying by the gas price at which the original transaction was generated.
 
 Gas refunds have the following fields in the `ActionReceipt`:
 


### PR DESCRIPTION
NEP-536 adds the gas refund fee, which has been stabilized for protocol version 78.

This updates the specification to reflect the changes.