### PR TITLE
Update nep-0001.md

### DIFF
--- a/neps/nep-0001.md
+++ b/neps/nep-0001.md
@@ -1,70 +1,68 @@
 ---
 NEP: 1
 Title: NEP Purpose and Guidelines
-Authors: Bowen W. <bowen@near.org>, Austin Baggio <austin.baggio@near.org>, Ori A. <ori@near.org>, Vlad F. <frol@near.org>;
-Status: Approved
+Authors: Bowen W. <bowen@near.org>, Austin Baggio <austin.baggio@near.org>, Ori A. <ori@near.org>, Vlad F. <frol@near.org>, Guillermo G. <guillermo@near.dev>;
+Status: Draft
 DiscussionsTo: https://github.com/near/NEPs/pull/333
 Type: Developer Tools
-Version: 1.1.0
+Version: 2.0.0
 Created: 2022-03-03
-Last Updated: 2023-03-05
+Last Updated: 2025-08-04
 ---
 
 ## Summary
 
-A NEAR Enhancement Proposal (NEP) is a design document that specifies reusable and interoperable components integrated across the NEAR ecosystem.
+NEAR Enhancement Proposals (NEPs) are design document that describe standards for the NEAR platform, including core protocol specifications, contract standards, and wallet APIs. Each NEP provides concise technical specifications and the rational behind its proposed enhancement.
 
-NEPs are the primary mechanism for evolving NEAR’s runtime, Smart Contract Standards, and Wallets ecosystem in a community-driven way. NEPs provide a concise technical specification and a rationale for the feature. The NEP author is responsible for building consensus within the community and documenting dissenting opinions. The typical primary audience for NEPs are the developers of the NEAR reference implementations and decentralized application developers.
+Each NEP is championed by a community member, which builds consensus within the community and sheperds the NEP from ideation to completion. The NEP process is designed to be open and transparent, allowing anyone in the NEAR community to propose, discuss, and review ideas for improving the NEAR ecosystem. 
 
-NEPs are stored as text files in a versioned repository, allowing for easy historical tracking. A list of NEPs is available on [GitHub](https://github.com/near/NEPs).
+All NEPs are stored as text files in a [versioned repository](https://github.com/near/NEPs), allowing for easy historical tracking.
 
 ## Motivation
 
-The purpose of the NEP process is to ensure the seamless evolution of the NEAR platform and to empower the community to contribute to its development. Given the complexity and number of participants involved across the ecosystem, a well-defined process helps ensure transparency, security, and stability.
+The purpose of the NEP process is to give the community a way to propose, discuss, and document changes to the NEAR ecosystem in a structured manner. Given the complexity and number of participants involved across the ecosystem, a well-defined process helps ensure transparency, security, and stability.
 
 ## NEP Types
 
-There are four kinds of NEPs:
+There are three kinds of NEPs:
 
-1. A **Protocol** NEP describes a new feature of the NEAR protocol.
-2. A **Contract Standards** NEP specifies NEAR Smart Contract interfaces for a reusable concept in the NEAR ecosystem.
-3. A **Wallet Standards** NEP specifies ecosystem-wide APIs for Wallet implementations.
-4. A **Developer Tools** NEP defines norms and guidelines for developer tooling in the NEAR ecosystem.
-
-Currently, all types of NEPs follow the same process, but for Protocol NEPs a draft implementation is required.
+1. A **Protocol** NEP describes a new feature of the NEAR protocol (e.g. [NEP-264](https://github.com/near/NEPs/blob/master/neps/nep-0264.md), [NEP-366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md))
+2. A **Contract Standards** NEP specifies NEAR smart contract interfaces for a reusable concept in the NEAR ecosystem (e.g. [NEP-141](https://github.com/near/NEPs/blob/master/neps/nep-0141.md), [NEP-171](https://github.com/near/NEPs/blob/master/neps/nep-0171.md))
+3. A **Wallet Standards** NEP specifies ecosystem-wide APIs for Wallet implementations (e.g. [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md))
 
 ## Submit a NEP
 
+Each NEP must have a champion that proposes a new idea, shepherds the discussions in the appropriate forums to build community consensus, proposes the NEP and help it progress toward completion.
+
 ### Start with ideation
 
-Everyone in the community is welcome to propose, discuss, and review ideas to improve the NEAR protocol and standards. The NEP process begins with a [new idea](https://www.neardevgov.org/blog/how-to-ideate-in-the-near-developer-governance) for the NEAR ecosystem. A single NEP should contain a single key proposal or new idea.
+Everyone in the community is welcome to propose, discuss, and review ideas to improve the NEAR protocol and standards. The NEP process begins with a new idea for the NEAR ecosystem.
 
-Each NEP must have an author: Someone who writes the NEP using the style and format described below. The author, or another champion, shepherds the discussions in the appropriate forums and attempts to build community consensus around the idea to help it progress toward completion.
+Before submitting a NEP, publicly check if your idea is original and relevant to the NEAR community. This saves time and avoids proposing something already discussed or unsuitable for most users.
 
-Before submitting a NEP, the author should first attempt to ascertain whether the idea is NEP-able. Vetting an idea publicly before writing a NEP saves the potential author time. Asking the NEAR community first if the idea is original helps prevent effort on something guaranteed to be rejected based on prior discussions. It also helps ensure the idea applies to the entire community. Just because an idea sounds good to the author does not mean it will work for most people in most use cases.
-
-In general, the process for socializing an idea is:
-
-- **Check prior proposals:** Many ideas for changing NEAR come up frequently. Please search the [Dev Gov Gigs Board](https://devgovgigs.near.social), the [NEAR Forums](https://gov.near.org), and NEPs in this repo before proposing something new.
-- **Share the idea:** Submit your [idea](https://www.neardevgov.org/blog/how-to-ideate-in-the-near-developer-governance) on the [Dev Gov Gigs Board](https://devgovgigs.near.social).
-- **Get feedback:** The [Dev Gov Gigs Board](https://devgovgigs.near.social) has comment threading which allows the community to ideate, ask questions, wrestle with approaches, etc. If more immediate responses are desired, consider bringing the conversation to the appropriate [Community Group](https://gov.near.org/c/dev/community-groups/103).
+- **Check prior proposals:** Many ideas for changing NEAR come up frequently. Please search the [issues](https://github.com/near/NEPs/issues) and NEPs in this repo before proposing something new.
+- **Share the idea:** Submit a new [issue](https://github.com/near/NEPs/issues) explaining the problem you want to tackle, and your proposed solution.
+- **Get feedback:** Share the issue to the appropriate community group:
+        - Wallet Group: https://nearbuilders.com/tg-wallet
+        - Protocol: https://near.zulipchat.com/
+        - Contract Standards: https://t.me/NEAR_Tools_Community_Group
 
 ### Submit a NEP Draft
 
-Following the above initial discussions, the author should submit a NEP draft into the GitHub NEP repository. The draft NEP must follow the [NEP-0000 template](https://github.com/near/NEPs/blob/master/nep-0000-template.md), or else it will fail the review immediately.
-
-To submit a NEP draft as a pull request, the NEP author should:
+Following the above initial discussions, the author should submit a NEP draft in the form of a `Draft Pull Request`:
 
 1. Fork the [NEPs repository](https://github.com/near/NEPs).
-2. Copy `nep-0000-template.md` to `neps/nep-0000-my-feature.md` (where “my-feature” is descriptive; don’t assign a NEP number yet).
+2. Copy `nep-0000-template.md` to `neps/nep-xxxx.md` (do **not** assign a NEP number yet).
 3. Fill in the NEP following the NEP template guidelines. For the Header Preamble, make sure to set the status as “Draft.”
 4. Push this to your GitHub fork and submit a pull request.
-5. Now that your NEP has an open pull request, use the pull request number to update your `0000` prefix. For example, if the PR is 305, the NEP should be `neps/nep-0305-my-feature.md`.
+5. Now that your NEP has an open pull request, use the pull request number to update your `0000` prefix. For example, if the PR is 305, the NEP should be `neps/nep-0305.md`.
 6. Push this to your GitHub fork and submit a pull request. Mention the @near/nep-moderators in the comment and turn the PR into a "Ready for Review" state once you believe the NEP is ready for review.
 
 ## NEP Lifecycle
 
-The NEP process begins when an author submits a [NEP draft](#submit-a-nep-draft). The NEP lifecycle consists of three stages: draft, review, and voting, with two possible outcomes: approval or rejection. Throughout the process, various roles play a critical part in moving the proposal forward. Most of the activity happens asynchronously on the NEP within GitHub, where all the roles can communicate and collaborate on revisions and improvements to the proposal.
+The NEP process begins when an author submits a [NEP draft](#submit-a-nep-draft). The NEP lifecycle consists of three stages: draft, review, and voting, with two possible outcomes: approval or rejection.
+
+Throughout the process, various roles play a critical part in moving the proposal forward. Most of the activity happens asynchronously on the NEP within GitHub, where all the roles can communicate and collaborate on revisions and improvements to the proposal.
 
 ![NEP Process](https://user-images.githubusercontent.com/110252255/201413632-f72743d6-593e-4747-9409-f56bc38de17b.png)
 
@@ -127,7 +125,7 @@ The reviewer is responsible for reviewing the technical feasibility of a NEP and
 **Approver** (Working Groups)<br />
 _Selected by the Dev Gov DAO in the bootstrapping phase_
 
-The working group is a selected committee of 3-7 recognized experts who are responsible for coordinating the public review and making decisions on a NEP in a fair and timely manner. There are multiple working groups, each one focusing on a specific ecosystem area, such as the Protocol or Wallet Standards. They assign reviewers to proposals, provide feedback to the author, and attend public calls to vote to approve or reject the NEP. Learn more about the various working groups at [neardevgov.org](http://neardevgov.org/).
+The working group is a selected committee of 3-7 recognized experts who are responsible for coordinating the public review and making decisions on a NEP in a fair and timely manner. There are multiple working groups, each one focusing on a specific ecosystem area, such as the Protocol or Wallet Standards. They assign reviewers to proposals, provide feedback to the author, and attend public calls to vote to approve or reject the NEP.
 
 ### NEP Communication
 


### PR DESCRIPTION
This PR proposes updates to the current `nep-0001.md` - the NEP that defines the `NEP Purpose and Guidelines` - with the aim of simplifying it and fixing some minor issues:

#### 1. Too Verbose
The current `nep-001` is too verbose, to the point where simple things seams harder than intended (e.g. how to create a NEP)

#### 2 . Extinct Dev Gov Gigs Board
`nep-001` contains mentions to `Dev Gov Gigs` board, which no longer exists.

The good news is that actually, most of the NEPs followed the classic Github process of creating an issue, debating on it, creating a PR and eventually resolve it (with a `merge` or  a `decline`)

I have updated the `nep-0001` to better reflect this naturally happening flow, moving away from "ideating and sharing in the devgovgigs" to "create and discuss ideas on github issues"

#### 3. Removed `tool` NEP category
As far as I can tell, not a single `tools` NEP was created, and that makes sense, as tools tend to reflect opinionated takes on how to realize / tackle a specific task.

I would go as long as to argue that it is **best** for the community to not standardize tools on any way.