### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: markdown-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # lint only changed files


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0