### PR TITLE
NEP-635: P256 host function

### DIFF
--- a/neps/nep-0622.md
+++ b/neps/nep-0622.md
@@ -1,0 +1,114 @@
+---
+NEP: 622
+Title: P-256 ECDSA Signature Verification Host Function
+Authors: Bowen Wang <bowen@nearone.org>
+Status: Draft
+DiscussionsTo: https://github.com/near/NEPs/pull/0000
+Type: Runtime Spec
+Category: Protocol
+Version: 1.0.0
+Created: 2026-01-24
+Last Updated: 2026-01-24
+---
+
+## Summary
+
+This NEP proposes adding a host function, `p256_verify`, to verify ECDSA signatures over the P-256 curve (secp256r1, prime256v1). The host function exposes a native implementation in the runtime, enabling smart contracts to verify P-256 signatures at substantially lower gas cost than a WASM-based implementation.
+
+## Motivation
+
+P-256 verification is a hard requirement for multiple workloads on NEAR today, and the current WASM path is prohibitively expensive:
+
+- Near Intents relies on passkeys (WebAuthn), which use P-256 ECDSA. A native host function substantially reduces verification gas and enables higher throughput for intents.
+- TEE attestation verification depends on the `dcap-qvl` library, which uses P-256. The latest `dcap-qvl` does not fit within NEAR's gas limits when compiled to WASM, and a host function would reduce the cost of `dcap-qvl::verify::verify()` (see https://github.com/Phala-Network/dcap-qvl/issues/99).
+- Benchmarks show that compiling the crypto library to WASM directly consumes ~46 Tgas for verifying a 32-byte message, while the host function consumes ~0.45 Tgas, a reduction of over 100x.
+
+## Rationale and alternatives
+
+Adding a dedicated host function provides an immediate and predictable gas reduction for a widely used cryptographic primitive. The runtime already includes mature RustCrypto implementations, and the host function design is consistent with existing cryptography host functions such as `ed25519_verify`.
+
+Alternatives considered:
+
+- Improve WASM compilation performance or use new compiler backends. This is a large, cross-cutting effort and does not guarantee acceptable costs for P-256 verification in the near term.
+- Increase gas limits or allow special-case gas budgets. This adds policy complexity and does not address the root performance gap.
+- Require contracts to verify P-256 signatures off-chain. This shifts trust and reduces on-chain verifiability, which is undesirable for intents and TEE attestations.
+
+## Specification
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### Protocol feature
+
+The host function MUST be guarded by the protocol feature flag `p256_verify`. When disabled, the import MUST be unavailable to contracts.
+
+### Host function
+
+```rust
+extern "C" {
+  /// Verify a P-256 ECDSA signature for a message and public key.
+  ///
+  /// - `signature` MUST be 64 bytes encoded as `r || s` (32 bytes each, big-endian).
+  /// - `public_key` MUST be a 33-byte compressed SEC1 encoding.
+  /// - `message` is the exact byte sequence to verify (no hashing is performed).
+  ///
+  /// Returns:
+  /// - 1 if the signature verifies
+  /// - 0 if the signature does not verify or cannot be parsed
+  ///
+  /// # Errors
+  ///
+  /// - If `signature` length is not 64, the runtime MUST raise `P256VerifyInvalidInput`.
+  /// - If `public_key` length is not 33, the runtime MUST raise `P256VerifyInvalidInput`.
+  /// - If any pointer is out of bounds, the runtime MUST raise `MemoryAccessViolation`.
+  fn p256_verify(
+    sig_len: u64,
+    sig_ptr: u64,
+    msg_len: u64,
+    msg_ptr: u64,
+    public_key_len: u64,
+    public_key_ptr: u64,
+  ) -> u64;
+}
+```
+
+Each input can be in memory or in a register. If the length argument is set to `u64::MAX`, the corresponding pointer is interpreted as a register ID. The runtime MUST apply the standard input cost for reading memory or registers.
+
+### Gas cost
+
+The gas cost MUST be computed as:
+
+`input_cost(num_bytes_signature) + input_cost(num_bytes_message) + input_cost(num_bytes_public_key) + p256_verify_base + p256_verify_byte * num_bytes_message`
+
+### SDK exposure
+
+Once enabled, the runtime SHOULD expose a higher-level helper in `near-sdk` as:
+
+```rust
+pub fn p256_verify(signature: &[u8], message: &[u8], public_key: &[u8]) -> bool;
+```
+
+## Reference-level specification
+
+The reference implementation in `nearcore`:
+
+- Uses the RustCrypto `p256` crate to parse `Signature::from_slice` and `VerifyingKey::from_sec1_bytes`.
+- Returns `0` for parsing failures or verification failures, and raises `P256VerifyInvalidInput` for invalid lengths.
+- Charges `p256_verify_base` once and `p256_verify_byte` per message byte, in addition to the standard input costs.
+
+## Security Implications (Optional)
+
+This host function does not perform hashing or domain separation. Callers MUST ensure that the message passed to `p256_verify` follows the correct protocol (for example, WebAuthn uses SHA-256 over the signed data). The runtime only checks signature and key encoding constraints as specified above.
+
+## Unresolved Issues (Optional)
+
+- Whether to support uncompressed SEC1 public keys (65 bytes) in addition to compressed keys.
+- Whether to support DER-encoded ECDSA signatures in addition to raw `r || s` encoding.
+
+## Future possibilities
+
+- Batch verification for P-256 signatures if proven beneficial for intents or attestations.
+- Additional host functions for other curves used by standard protocols or TEEs.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -3,7 +3,7 @@ NEP: 622
 Title: P-256 ECDSA Signature Verification Host Function
 Authors: Bowen Wang <bowen@nearone.org>
 Status: Draft
-DiscussionsTo: https://github.com/near/NEPs/pull/0000
+DiscussionsTo: https://github.com/near/NEPs/pull/0635
 Type: Runtime Spec
 Category: Protocol
 Version: 1.0.0

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -94,7 +94,7 @@ pub fn p256_verify(signature: [u8; 64], message: [u8; 32], public_key: [u8; 33])
 
 The reference implementation in `nearcore`:
 
-- Uses the RustCrypto `p256` crate to parse `Signature::from_slice` and `VerifyingKey::from_sec1_bytes`.
+- Uses the RustCrypto `p256` crate - [audited here](https://reports.zksecurity.xyz/reports/near-p256/) - to parse `Signature::from_slice` and `VerifyingKey::from_sec1_bytes`.
 - Returns `0` for parsing failures or verification failures, and raises `P256VerifyInvalidInput` for invalid lengths.
 - Charges `p256_verify_base` once and `p256_verify_byte` per message byte, in addition to the standard input costs.
 

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -49,7 +49,10 @@ extern "C" {
   ///
   /// - `signature` MUST be 64 bytes encoded as `r || s` (32 bytes each, big-endian).
   /// - `public_key` MUST be a 33-byte compressed SEC1 encoding.
-  /// - `message` is the exact byte sequence to verify (no hashing is performed).
+  /// - `message` is the pre-hashed digest to verify (no hashing is performed by the host function).
+  ///   Callers MUST hash the signed data with an appropriate cryptographic hash function before
+  ///   calling `p256_verify` (e.g., WebAuthn uses SHA-256). If `message` is not exactly 32 bytes,
+  ///   it will be truncated or zero-padded to 32 bytes to match the P-256 field size.
   ///
   /// Returns:
   /// - 1 if the signature verifies

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -84,7 +84,7 @@ The gas cost MUST be computed as:
 Once enabled, the runtime SHOULD expose a higher-level helper in `near-sdk` as:
 
 ```rust
-pub fn p256_verify(signature: &[u8], message: &[u8], public_key: &[u8]) -> bool;
+pub fn p256_verify(signature: [u8; 64], message: [u8; 32], public_key: [u8; 33]) -> bool;
 ```
 
 ## Reference-level specification


### PR DESCRIPTION
Proposal to add ECDSA P256 signature verification as a host function in the runtime. Implementation in https://github.com/near/nearcore/pull/14927