### PR TITLE
NEP-639: Dynamic Resharding

### DIFF
--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -24,7 +24,7 @@ With dynamic resharding, each shard proposes a split during chunk application wh
 As the NEAR ecosystem grows, the network needs the ability to scale out automatically. Dynamic resharding addresses this by:
 
 - **Eliminating manual coordination**: Shard splits are proposed and executed by the protocol itself, based on observed state size.
-- **Reacting to demand**: Overloaded shards are detected and split within two epochs (~24 hours on mainnet), rather than waiting weeks for a protocol upgrade cycle.
+- **Reacting to demand**: Overloaded shards are detected and split within two epochs (~14.5 hours on mainnet), rather than waiting weeks for a protocol upgrade cycle.
 - **Enabling continuous scaling**: The network can grow from its current shard count toward a configurable maximum without any human intervention.
 
 ## Specification
@@ -331,10 +331,10 @@ A non-deterministic split algorithm would cause validators to disagree on the sh
 
 ### Validation of Split Proposals
 
-Chunk producers could attempt to forge `proposed_split` values to manipulate which shard gets split or the boundary account. This is prevented by:
+Both chunk producers and block producers could attempt to forge their respective resharding fields to manipulate which shard gets split or the boundary account:
 
-1. Chunk validators recompute `proposed_split` from the state witness and reject mismatches (`InvalidChunkHeaderShardSplit`).
-2. Block validators recompute `shard_split` from the chunk headers in the block and reject mismatches (`InvalidBlockHeaderShardSplit`).
+1. **Chunk header forgery**: A chunk producer could embed a false `proposed_split` in the chunk header (e.g., proposing a split for a shard that doesn't meet the threshold, or proposing a wrong boundary account). This is prevented by chunk validators, who recompute `proposed_split` from the state witness and reject mismatches (`InvalidChunkHeaderShardSplit`).
+2. **Block header forgery**: A block producer could embed a false `shard_split` in the block header (e.g., selecting a different shard than the one with the highest memory usage, or ignoring a valid proposal). This is prevented by block validators, who recompute `shard_split` from the chunk headers in the block and reject mismatches (`InvalidBlockHeaderShardSplit`).
 
 ### DoS via Threshold Manipulation
 
@@ -384,7 +384,7 @@ Allowing more than one split per epoch was considered but rejected to limit the 
 
 - The network can scale automatically in response to demand without protocol upgrades.
 - Eliminates the operational burden of manual shard layout analysis and deployment.
-- Reduces reaction time from weeks (manual protocol upgrade) to ~24 hours (two epochs on mainnet).
+- Reduces reaction time from weeks (manual protocol upgrade) to ~14.5 hours (two epochs on mainnet).
 - Fully compatible with stateless validation -- split proposals are verifiable through state witnesses.
 - Builds directly on the proven Resharding V3 execution machinery.
 
@@ -392,6 +392,7 @@ Allowing more than one split per epoch was considered but rejected to limit the 
 
 - The split algorithm performs a greedy descent that is equivalent to binary search on a monotonic cumulative distribution, so it finds the optimal boundary. However, a perfectly balanced split is not always achievable due to inherent constraints (indivisible accounts, minimum boundary length).
 - Thread pool sizes are based on `max_number_of_shards` rather than the current shard count, which is slightly wasteful but safe.
+- Mainnet and testnet shard layouts will diverge, since splits are driven by actual state size which differs between the two networks. This is expected and by design, but means tooling and tests cannot assume a fixed shard layout for either network.
 
 ### Negative
 
@@ -409,9 +410,6 @@ External tooling that queries shard layouts via the `EXPERIMENTAL_protocol_confi
 
 ## Unresolved Issues
 
-- **Shard assignment stability across resharding**: Validator-to-shard assignment currently uses `ShardIndex`, so a resharding event that changes shard indices may cause excessive validator reassignment. The assignment algorithm should be made resharding-aware to minimize unnecessary churn.
-- **Shadow validation across resharding boundaries**: Shadow validation currently breaks at resharding boundaries.
-- **Fork network tooling**: The fork-network tool does not yet fully support dynamic resharding.
 - **SPICE integration**: Multiple integration points between the SPICE feature and resharding transitions remain incomplete (chunk executor, data distributor, chunk validation, chunk application).
 
 ## Changelog

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -77,7 +77,9 @@ pub struct DynamicReshardingConfig {
     pub max_number_of_shards: NumShards,
 
     /// Minimum epochs between consecutive resharding events.
-    /// A value of 0 allows resharding every epoch.
+    /// A value of 0 allows resharding every epoch (gap of 1 epoch between
+    /// effective layouts); a value of N enforces a gap of at least N+1 epochs
+    /// between effective layouts.
     pub min_epochs_between_resharding: EpochHeight,
 
     /// Shards to force-split regardless of memory thresholds.
@@ -101,7 +103,19 @@ pub enum ShardLayoutConfig {
 
 When `ShardLayoutConfig::Dynamic` is active, the shard layout is stored in `EpochInfo` rather than derived from the protocol version. This allows different epochs at the same protocol version to have different shard layouts.
 
+#### Source of Configuration Values
+
+`DynamicReshardingConfig` values (thresholds, limits, force/block lists) are part of `EpochConfig` and are loaded from per-protocol-version JSON files baked into the `neard` binary at build time, located under `core/primitives/res/epoch_configs/{mainnet,testnet}/<protocol_version>.json`. They are not exposed as node-operator-tunable settings and cannot be overridden at runtime.
+
+Updating any value therefore requires a protocol upgrade: a new protocol version is added with a new epoch config JSON file, and the network adopts the change once enough nodes vote to upgrade. This is intentional -- thresholds and limits affect consensus (every validator must agree on whether a split should be proposed), so they MUST be uniform across the network. Initial mainnet values will be set conservatively (see [Limiting the Blast Radius](#limiting-the-blast-radius)) and tuned through subsequent protocol upgrades as operational experience accumulates.
+
 With dynamic resharding, per-shard default cache sizes are no longer derived from the protocol version, since the shard layout is not known at compile time. Nodes use uniform default cache sizes across all shards. Performance testing on mainnet state has shown no significant impact from this change. Node operators can still override cache sizes via manual configuration if needed.
+
+### Limiting the Blast Radius
+
+When dynamic resharding is first released on mainnet, `max_number_of_shards` will be set to one more than the current shard count. This caps the damage from any single resharding event: at most one new shard can be created before further splits are blocked, regardless of memory thresholds. Successive protocol upgrades will raise the limit gradually as confidence in the feature grows. With this conservative rollout, in practice we expect that disabling dynamic resharding will never be necessary -- the shard limit itself acts as the safety mechanism.
+
+In the unlikely event that the shard limit proves insufficient (for instance, a previously-allowed split turns out to be problematic and we want to prevent any further splits while we investigate), an emergency mitigation is to ship a protocol upgrade that sets `block_split_shards` to include every existing shard ID. This blocks all further splits while leaving the rest of the protocol unchanged. We note, however, that if a protocol upgrade is needed anyway, it is generally preferable to use that upgrade to fix the underlying issue rather than to disable resharding.
 
 ### Finding the Optimal Split Point
 
@@ -164,6 +178,17 @@ During chunk application, the runtime checks whether a shard should be split. Th
    - If `total_mem_usage >= memory_usage_threshold`: compute the split via `find_trie_split`. If both children would have at least `min_child_memory_usage`, **propose the split**.
 
 The result (`Option<TrieSplit>`) is stored in `ChunkExtra` and embedded in the chunk header via the new `ShardChunkHeaderInnerV5.proposed_split` field.
+
+#### Behavior with Missing Chunks
+
+When a chunk is missing in a block, the previous chunk header for that shard is reused (standard NEAR behavior). The reused header carries whatever `proposed_split` was set on the last produced chunk. This has the following implications for dynamic resharding:
+
+- If the shard had at least one chunk produced within the "possibly-last-block" window, its `proposed_split` is valid (the shard's state cannot change while its chunks are missing) and is correctly carried forward through the missing-chunk headers. The shard is considered normally for selection.
+- If the shard's last produced chunk predates that window, its `proposed_split` is `None` (the proposal is only computed near the epoch boundary). The shard is silently skipped this epoch and will be reconsidered in the next.
+
+A subtle consequence of the second case: if multiple shards are above the split threshold and the **largest** one is the one whose chunks went missing during the window, its `None` excludes it from the picker and a smaller-but-eligible shard gets picked instead. The split of the larger shard is then delayed by at least one epoch (and longer if `min_epochs_between_resharding > 0`, since the cooldown will apply to the smaller shard's split that just occurred). The split chosen is still legitimate (the smaller shard is above threshold by construction), so this is a degradation in priority, not in correctness.
+
+In all cases, correctness is preserved: chunk-header validation compares `proposed_split` against the matching `ChunkExtra` from when the chunk was applied, and these agree by construction. Missing chunks can only delay or substitute a split, never produce an incorrect one.
 
 ### Selecting the Split at Epoch Boundary
 
@@ -350,10 +375,14 @@ An attacker could try to force unnecessary resharding by inflating a shard's sta
 
 Resharding requires additional memory and disk I/O (for flat state migration). The `max_number_of_shards` parameter is used to size thread pools conservatively, preventing resource exhaustion from unexpected shard count increases.
 
+The compute cost of running the split-search algorithm itself is negligible: tests on mainnet state with a release-optimized binary and memtries enabled showed `find_trie_split` completing in under 1 ms for every shard.
+
 The peak memory usage during resharding deserves particular attention:
 
 - **Hybrid MemTrie sharing**: When the parent memtrie is frozen at the resharding boundary, its memory is wrapped in an `Arc<STArenaMemory>` and shared between both child shards' `HybridArena`s. There is **no immediate duplication** of memory at the moment of the split.
-- **Gradual growth post-split**: After resharding, each child's `HybridArena` accumulates new owned memory as state changes. The shared frozen parent memory is retained until the background flat-state resharding completes and the children's memtries are rebuilt from scratch (typically within the same epoch). At that point the frozen parent memory is dropped.
+- **Frozen-layer orphan accumulation**: As state mutates after the split, modifications allocate new nodes in each child's owned layer. Nodes in the frozen (shared) layer that become unreachable are **not** reclaimed: the trie's refcount logic intentionally short-circuits for shared memory (`add_ref` and `remove_ref` are no-ops when the node is in the frozen layer; see `core/store/src/trie/mem/node/encoding.rs`), so orphaned frozen nodes remain resident. The owned layer grows in parallel with each modification, so the **total** memory occupied by a child's hybrid memtrie keeps growing for as long as the node tracks that child shard. We recommend operators provision an additional **10–20%** of the largest shard's memtrie size as headroom for this effect. This range is an engineering estimate, not empirically measured -- it should be refined once mainnet measurements are available. Two mechanisms release the hybrid memtrie (and its frozen layer) entirely:
+  - **Automatic, via assignment changes**: when a node's assignment changes such that it stops tracking a child shard, that shard's hybrid memtrie is dropped at the epoch boundary (`retain_memtries`).
+  - **Manual, via node restart**: an operator who observes elevated RAM usage can restart the node. After restart, the memtrie is reloaded from flat storage as a plain `STArena` with no frozen layer, recovering the orphaned memory.
 - **Pre-loading is the dominant cost**: Because dynamic resharding can split any shard at any epoch boundary, a validator whose assignment changes such that it must track a child of a soon-to-be-split shard needs to pre-load the parent memtrie before the split executes. During this preparation window (epoch N+1, between the split decision in epoch N's last block and execution at the N+1 → N+2 boundary), the validator holds **two memtries simultaneously**: its currently-tracked shard plus the parent shard being prepared.
 
 In the pessimistic case, validators MUST be provisioned with enough RAM to hold the two largest shards' memtries concurrently. This is the fundamental constraint dynamic resharding adds compared to [Resharding V3][NEP-568], where the parent shard to be loaded was known weeks in advance via the protocol upgrade schedule. Operators SHOULD treat "2× the size of the largest current shard's memtrie" as the minimum RAM headroom available beyond their currently-tracked shard.
@@ -373,10 +402,6 @@ Instead of memory usage, gas (compute) utilization could drive resharding decisi
 - Gas usage is more volatile and harder to threshold reliably.
 - Memory (state size) is the primary constraint for node operators (RAM for memtries).
 - Gas-based resharding could be added as a complementary signal in a future extension.
-
-### Shard Merging
-
-This NEP only supports splitting. Merging underutilized shards would allow the network to reclaim resources, but introduces significant additional complexity (reversing the split map, merging state tries, reassigning receipts). Merging is deferred to a future NEP as discussed in [Resharding V3's Future Possibilities][NEP-568].
 
 ### Split Multiple Shards per Epoch
 

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -125,14 +125,14 @@ pub struct TrieSplit {
 }
 ```
 
-NEAR's state trie is a 16-ary Merkle-Patricia trie where each node stores a cumulative `memory_usage` for its subtree. Of the trie's column subtrees (identified by the first byte of the key), only four are keyed by account ID and therefore relevant to the split:
+NEAR's state trie is a 16-ary Merkle-Patricia trie where each node stores a cumulative `memory_usage` for its subtree. Several column subtrees (identified by the first byte of the key) are keyed by account ID -- the full list is in `COLUMNS_WITH_ACCOUNT_ID_IN_KEY`. Of these, the split algorithm considers only the four columns that dominate state size in practice:
 
 - **ACCOUNT** (column 0): account records
 - **CONTRACT_CODE** (column 1): WASM contract code
 - **ACCESS_KEY** (column 2): access keys
 - **CONTRACT_DATA** (column 9): contract key-value storage
 
-Other columns (delayed receipts, buffered receipts, promise yields, etc.) store shard-global state not keyed by account ID and are excluded from the split search.
+The remaining account-keyed columns (received data, postponed receipts, promise yield receipts, etc.) are typically small and including them in the split search would add overhead without meaningfully improving the split quality. Columns not keyed by account ID (delayed receipts, buffered receipts, promise yield indices, etc.) store shard-global state and are inherently excluded.
 
 The algorithm performs a greedy binary-search-like traversal, descending through all four subtrees simultaneously:
 
@@ -146,7 +146,7 @@ The algorithm performs a greedy binary-search-like traversal, descending through
 6. Track the best split (lowest `mem_diff = |left_memory - right_memory|`).
 7. Stop when the ACCOUNT subtree reaches a leaf or when further descent cannot improve the split.
 
-The resulting boundary account MUST be at least 2 bytes long and composed of valid UTF-8. If the natural descent terminates too early, the algorithm force-descends into the first available child until the minimum path length is met.
+The resulting boundary account MUST satisfy NEAR's existing account ID validity rules (minimum 2 characters, valid UTF-8). If the natural descent terminates too early to produce a valid account ID, the algorithm force-descends into the first available child until the minimum path length is met.
 
 The algorithm works with both in-memory tries (memtries) and disk-based tries, and is deterministic and reproducible from state witnesses (recorded trie storage), which is critical for stateless validation.
 
@@ -173,7 +173,7 @@ At the last block of each epoch, the block producer:
 2. Calls `get_upcoming_shard_split()`, which:
    - Verifies dynamic resharding is enabled (via `ShardLayoutConfig::Dynamic`).
    - Checks the resharding cooldown: `epoch_height - last_resharding >= min_epochs_between_resharding`.
-   - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority; otherwise the shard with the highest `total_memory()` wins.
+   - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority; otherwise the shard with the highest `total_memory()` wins. In the (extremely unlikely in production, but possible in tests) case of a tie, the shard with the highest `ShardId` wins -- the selection key is the tuple `(total_memory, shard_id)`, ensuring determinism.
 3. Embeds the result as `shard_split: Option<(ShardId, AccountId)>` in `BlockHeaderInnerRestV6`.
 
 Only the last block of each epoch MAY carry a non-None `shard_split`.
@@ -187,7 +187,8 @@ During `EpochManager::finalize_epoch()`, when finalizing epoch N:
    - **Static fallback**: If the next-next epoch config specifies a static layout, use it (backward compatibility).
    - **Transitional**: If the current epoch doesn't have dynamic resharding enabled, carry forward the existing layout.
    - **Dynamic**: If a split is present, derive a new `ShardLayoutV3` from the current layout. New shard IDs are assigned as `max(existing_shard_ids) + 1` and `max(existing_shard_ids) + 2`.
-3. Store the resulting layout in `EpochInfoV5.shard_layout` for epoch N+2.
+3. **Stale-split guard**: If `shard_split` references a shard that no longer exists in the next layout (e.g. it was already split in a previous epoch via a static-layout protocol upgrade), the split is skipped and the next layout is carried forward unchanged. This prevents inconsistencies when a static and dynamic split happen to target the same shard in adjacent epochs.
+4. Store the resulting layout in `EpochInfoV5.shard_layout` for epoch N+2.
 
 The two-epoch delay (split decided at end of epoch N, takes effect in epoch N+2) gives the network one full epoch (N+1) to prepare: validators are reassigned, state migration begins, and memtries are pre-loaded.
 
@@ -231,7 +232,7 @@ This section lists data structures introduced or modified relative to [Reshardin
 | `DynamicReshardingConfig` | **New** | Resharding thresholds and limits |
 | `ShardLayoutConfig` | **New** | Enum: `Static` (legacy) or `Dynamic` |
 | `EpochInfoV5` | **New version** | Adds `shard_layout` and `last_resharding` fields |
-| `BlockHeaderInnerRestV6` | **New version** | Adds `shard_split: Option<(ShardId, AccountId)>` |
+| `BlockHeaderInnerRestV6` | **New version** | Adds `shard_split: Option<(ShardId, AccountId)>`, removes deprecated challenges fields |
 | `ShardChunkHeaderInnerV5` | **New version** | Adds `proposed_split: Option<TrieSplit>` |
 | `BlockInfoV4` | **New version** | Adds `shard_split`, removes deprecated `slashed` map |
 | `ChunkExtraV5` | **New version** | Adds `proposed_split: Option<TrieSplit>` |
@@ -243,7 +244,7 @@ This section lists data structures introduced or modified relative to [Reshardin
 `ShardLayoutV3` replaces V2 with a layout that stores the **full cumulative split history**:
 
 - `shards_split_map: ShardsSplitMapV3` — records every split across all generations, not just the most recent one.
-- `shards_ancestor_map: ShardsAncestorMapV3` — enables O(1) lookup of all ancestors for any shard, which is needed for shard tracking (determining which current shards a node must track based on which historical shards it was assigned to).
+- `shards_ancestor_map: ShardsAncestorMapV3` — enables O(log N) lookup of all ancestors for any shard (it is a `BTreeMap<ShardId, Vec<ShardId>>`), which is needed for shard tracking (determining which current shards a node must track based on which historical shards it was assigned to).
 - `last_split: ShardId` — tracks the most recently split shard.
 
 This cumulative history is essential because dynamic resharding can produce long chains of splits (e.g., shard A → B,C → B,D,E → ...) and every node must be able to resolve any historical shard ID to its current descendants.
@@ -307,7 +308,7 @@ The implementation is gated behind the `ProtocolFeature::DynamicResharding` feat
 - `chain/chain/src/chain.rs`: `maybe_start_memtrie_preload_for_resharding`, `postprocess_ready_block`
 - `core/store/src/trie/shard_tries.rs`: `spawn_background_memtrie_loading_for_shard`, `try_finalize_background_memtrie_loading`, `retain_memtries`
 - `core/store/src/trie/mem/loading.rs`: `apply_deltas_to_memtries`
-- `core/store/src/flat/storage.rs`: `hold_flat_head`, `release_flat_head_hold`
+- `core/store/src/flat/storage.rs`: `hold_flat_head` (returns a `FlatHeadHold` guard that releases the hold when dropped)
 
 ### Shard Layout Derivation
 
@@ -347,7 +348,17 @@ An attacker could try to force unnecessary resharding by inflating a shard's sta
 
 ### Resource Consumption During Resharding
 
-Resharding requires additional memory (for hybrid memtries) and disk I/O (for flat state migration). The two-epoch delay ensures nodes have adequate preparation time. The `max_number_of_shards` parameter is used to size thread pools conservatively, preventing resource exhaustion from unexpected shard count increases.
+Resharding requires additional memory and disk I/O (for flat state migration). The `max_number_of_shards` parameter is used to size thread pools conservatively, preventing resource exhaustion from unexpected shard count increases.
+
+The peak memory usage during resharding deserves particular attention:
+
+- **Hybrid MemTrie sharing**: When the parent memtrie is frozen at the resharding boundary, its memory is wrapped in an `Arc<STArenaMemory>` and shared between both child shards' `HybridArena`s. There is **no immediate duplication** of memory at the moment of the split.
+- **Gradual growth post-split**: After resharding, each child's `HybridArena` accumulates new owned memory as state changes. The shared frozen parent memory is retained until the background flat-state resharding completes and the children's memtries are rebuilt from scratch (typically within the same epoch). At that point the frozen parent memory is dropped.
+- **Pre-loading is the dominant cost**: Because dynamic resharding can split any shard at any epoch boundary, a validator whose assignment changes such that it must track a child of a soon-to-be-split shard needs to pre-load the parent memtrie before the split executes. During this preparation window (epoch N+1, between the split decision in epoch N's last block and execution at the N+1 → N+2 boundary), the validator holds **two memtries simultaneously**: its currently-tracked shard plus the parent shard being prepared.
+
+In the pessimistic case, validators MUST be provisioned with enough RAM to hold the two largest shards' memtries concurrently. This is the fundamental constraint dynamic resharding adds compared to [Resharding V3][NEP-568], where the parent shard to be loaded was known weeks in advance via the protocol upgrade schedule. Operators SHOULD treat "2× the size of the largest current shard's memtrie" as the minimum RAM headroom available beyond their currently-tracked shard.
+
+Note that a transient case of holding two memtries also exists today whenever a validator's assignment changes between epochs (independently of resharding). Dynamic resharding makes this case more frequent and less predictable.
 
 ## Alternatives
 

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -1,0 +1,448 @@
+---
+NEP: 639
+Title: Dynamic Resharding
+Authors: Adam Wierzbicki
+Status: Draft
+DiscussionsTo: https://github.com/near/nearcore/issues/14070
+Type: Protocol
+Version: 1.0.0
+Created: 2026-04-09
+LastUpdated: 2026-04-09
+Requires: 568
+---
+
+## Summary
+
+This proposal introduces dynamic resharding: a protocol-level mechanism that enables automatic splitting of shards based on their state size, without requiring a protocol upgrade. It replaces the static approach used by [Resharding V2][NEP-508] and [Resharding V3][NEP-568], where shard layout changes were hardcoded into specific protocol versions and required coordinated binary releases.
+
+With dynamic resharding, each shard proposes a split during chunk application when its memory usage exceeds a configurable threshold. The block producer for the last block of an epoch selects the best candidate, and the resulting shard layout takes effect two epochs later. The entire process is deterministic, validated through state witnesses, and requires no human intervention.
+
+## Motivation
+
+[Resharding V3][NEP-568] established the core infrastructure for splitting shards: instant MemTrie resharding, stateless validation of resharding proofs, state mapping for efficient storage, and flat state background resharding. However, V3 still requires the NEAR developer team to manually analyze shard utilization, determine boundary accounts, hardcode the new layout into the `neard` binary, and coordinate a protocol upgrade across the network. This process is slow, operationally expensive, and cannot react to sudden changes in demand.
+
+As the NEAR ecosystem grows, the network needs the ability to scale out automatically. Dynamic resharding addresses this by:
+
+- **Eliminating manual coordination**: Shard splits are proposed and executed by the protocol itself, based on observed state size.
+- **Reacting to demand**: Overloaded shards are detected and split within two epochs (~24 hours on mainnet), rather than waiting weeks for a protocol upgrade cycle.
+- **Enabling continuous scaling**: The network can grow from its current shard count toward a configurable maximum without any human intervention.
+
+## Specification
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### Overview
+
+Dynamic resharding extends the [Resharding V3][NEP-568] infrastructure with three new protocol mechanisms:
+
+1. **Split proposal**: During chunk application, each shard computes a proposed split point based on trie memory usage.
+2. **Split selection**: The block producer for the last block of an epoch collects proposals and selects the best candidate.
+3. **Layout derivation**: The epoch manager derives a new `ShardLayoutV3` for two epochs ahead.
+
+The actual resharding execution (MemTrie splitting, flat state migration, state mapping) reuses the [Resharding V3][NEP-568] machinery without modification.
+
+### Key Differences from Resharding V3
+
+| Aspect | Resharding V3 | Dynamic Resharding |
+|--------|--------------|-------------------|
+| **Trigger** | Manual: hardcoded in binary, tied to protocol version | Automatic: threshold-based, per-epoch evaluation |
+| **Boundary account** | Determined offline by the developer team | Computed algorithmically from trie memory usage |
+| **Shard layout source** | `EpochConfig` (determined by protocol version) | `EpochInfo` (stored per-epoch) |
+| **Configuration** | `ShardLayoutConfig::Static` | `ShardLayoutConfig::Dynamic` |
+| **Shard layout struct** | `ShardLayoutV2` (single-generation split map) | `ShardLayoutV3` (cumulative split history) |
+| **Chunk headers** | V4 | V5 (adds `proposed_split: Option<TrieSplit>`) |
+| **Block headers** | V5 | V6 (adds `shard_split: Option<(ShardId, AccountId)>`) |
+| **EpochInfo** | V4 | V5 (adds `shard_layout` and `last_resharding` fields) |
+| **Resharding cooldown** | N/A (manual scheduling) | Enforced via `min_epochs_between_resharding` |
+
+The execution path after a split is decided (MemTrie splitting, flat state resharding, state mapping, stateless validation, receipt handling) is **identical** to Resharding V3. See [NEP-568][NEP-568] for details on those mechanisms.
+
+### Configuration
+
+Dynamic resharding is controlled by `DynamicReshardingConfig`, stored in `EpochConfig` via the `ShardLayoutConfig::Dynamic` variant:
+
+```rust
+pub struct DynamicReshardingConfig {
+    /// Memory threshold over which a shard is marked for a split.
+    /// Calculated using TRIE_COSTS; roughly double the actual RAM usage
+    /// of the shard's memtrie (in bytes).
+    pub memory_usage_threshold: u64,
+
+    /// Minimum memory usage of each child shard. If either potential child
+    /// would fall below this, the parent shard will NOT be split.
+    pub min_child_memory_usage: u64,
+
+    /// Maximum number of shards in the network. No further splitting
+    /// occurs once this limit is reached.
+    pub max_number_of_shards: NumShards,
+
+    /// Minimum epochs between consecutive resharding events.
+    /// A value of 0 allows resharding every epoch.
+    pub min_epochs_between_resharding: EpochHeight,
+
+    /// Shards to force-split regardless of memory thresholds.
+    pub force_split_shards: Vec<ShardId>,
+
+    /// Shards that MUST NOT be split regardless of memory thresholds.
+    pub block_split_shards: Vec<ShardId>,
+}
+```
+
+The `ShardLayoutConfig` enum replaces the old `shard_layout` field in `EpochConfig`:
+
+```rust
+pub enum ShardLayoutConfig {
+    /// Legacy: layout defined inline, changed only via protocol upgrade.
+    Static { shard_layout: ShardLayout },
+    /// Dynamic: layout managed at runtime based on config thresholds.
+    Dynamic { dynamic_resharding_config: DynamicReshardingConfig },
+}
+```
+
+When `ShardLayoutConfig::Dynamic` is active, the shard layout is stored in `EpochInfo` rather than derived from the protocol version. This allows different epochs at the same protocol version to have different shard layouts.
+
+With dynamic resharding, per-shard default cache sizes are no longer derived from the protocol version, since the shard layout is not known at compile time. Nodes use uniform default cache sizes across all shards. Performance testing on mainnet state has shown no significant impact from this change. Node operators can still override cache sizes via manual configuration if needed.
+
+### Finding the Optimal Split Point
+
+The split algorithm finds an account ID boundary that divides a shard's state trie into two roughly equal halves by memory usage. The entry point is:
+
+```rust
+pub fn find_trie_split(trie: &Trie) -> Result<TrieSplit, FindSplitError>
+```
+
+The result:
+
+```rust
+pub struct TrieSplit {
+    /// Account ID boundary. Left shard gets accounts below this;
+    /// right shard gets this account and above.
+    pub boundary_account: AccountId,
+    /// Total memory_usage of the left part.
+    pub left_memory: u64,
+    /// Total memory_usage of the right part.
+    pub right_memory: u64,
+}
+```
+
+NEAR's state trie is a 16-ary Merkle-Patricia trie where each node stores a cumulative `memory_usage` for its subtree. Of the trie's column subtrees (identified by the first byte of the key), only four are keyed by account ID and therefore relevant to the split:
+
+- **ACCOUNT** (column 0): account records
+- **CONTRACT_CODE** (column 1): WASM contract code
+- **ACCESS_KEY** (column 2): access keys
+- **CONTRACT_DATA** (column 9): contract key-value storage
+
+Other columns (delayed receipts, buffered receipts, promise yields, etc.) store shard-global state not keyed by account ID and are excluded from the split search.
+
+The algorithm performs a greedy binary-search-like traversal, descending through all four subtrees simultaneously:
+
+1. At each branch node, aggregate children memory usage across all four subtrees.
+2. Compute a threshold: `total_memory / 2 - left_memory`.
+3. Find the "middle child" -- the nibble where the cumulative sum first exceeds the threshold.
+4. Descend into the middle child across all subtrees.
+5. At each position, evaluate two candidate splits:
+   - **Split A**: Use the current path as the boundary (middle memory goes to the right shard).
+   - **Split B**: Append "-0" to the current path, pushing the current account and its attached data (access keys, contract data) to the left shard and child accounts to the right. This handles "big middle accounts" with large contracts or many data entries.
+6. Track the best split (lowest `mem_diff = |left_memory - right_memory|`).
+7. Stop when the ACCOUNT subtree reaches a leaf or when further descent cannot improve the split.
+
+The resulting boundary account MUST be at least 2 bytes long and composed of valid UTF-8. If the natural descent terminates too early, the algorithm force-descends into the first available child until the minimum path length is met.
+
+The algorithm works with both in-memory tries (memtries) and disk-based tries, and is deterministic and reproducible from state witnesses (recorded trie storage), which is critical for stateless validation.
+
+### Proposing a Shard Split
+
+During chunk application, the runtime checks whether a shard should be split. This check is performed by `compute_proposed_split`, which:
+
+1. Verifies the `DynamicResharding` protocol feature flag is enabled.
+2. Checks that the next block could be the last of the epoch (using `is_next_block_possibly_last_in_epoch`). This conservative check may produce false positives but never false negatives.
+3. Verifies the resharding cooldown has elapsed (`can_reshard`).
+4. Delegates to `check_dynamic_resharding` which applies the following priority-ordered decision logic:
+   - If `num_shards >= max_number_of_shards`: **no split** (overrides everything, including force-split).
+   - If shard is in `force_split_shards`: **split** (regardless of memory thresholds).
+   - If shard is in `block_split_shards`: **no split** (regardless of memory thresholds).
+   - If `total_mem_usage >= memory_usage_threshold`: compute the split via `find_trie_split`. If both children would have at least `min_child_memory_usage`, **propose the split**.
+
+The result (`Option<TrieSplit>`) is stored in `ChunkExtra` and embedded in the chunk header via the new `ShardChunkHeaderInnerV5.proposed_split` field.
+
+### Selecting the Split at Epoch Boundary
+
+At the last block of each epoch, the block producer:
+
+1. Collects `proposed_split` values from all chunk headers in the block.
+2. Calls `get_upcoming_shard_split()`, which:
+   - Verifies dynamic resharding is enabled (via `ShardLayoutConfig::Dynamic`).
+   - Checks the resharding cooldown: `epoch_height - last_resharding >= min_epochs_between_resharding`.
+   - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority; otherwise the shard with the highest `total_memory()` wins.
+3. Embeds the result as `shard_split: Option<(ShardId, AccountId)>` in `BlockHeaderInnerRestV6`.
+
+Only the last block of each epoch MAY carry a non-None `shard_split`.
+
+### Deriving the New Shard Layout
+
+During `EpochManager::finalize_epoch()`, when finalizing epoch N:
+
+1. Read `block_info.shard_split()` from the last block of epoch N.
+2. Call `next_next_shard_layout()`, which has three phases:
+   - **Static fallback**: If the next-next epoch config specifies a static layout, use it (backward compatibility).
+   - **Transitional**: If the current epoch doesn't have dynamic resharding enabled, carry forward the existing layout.
+   - **Dynamic**: If a split is present, derive a new `ShardLayoutV3` from the current layout. New shard IDs are assigned as `max(existing_shard_ids) + 1` and `max(existing_shard_ids) + 2`.
+3. Store the resulting layout in `EpochInfoV5.shard_layout` for epoch N+2.
+
+The two-epoch delay (split decided at end of epoch N, takes effect in epoch N+2) gives the network one full epoch (N+1) to prepare: validators are reassigned, state migration begins, and memtries are pre-loaded.
+
+### Migration from Static to Dynamic Resharding
+
+When the network first enables dynamic resharding, the current shard layout (`ShardLayoutV2`) cannot directly become a `ShardLayoutV3` because V2 only stores single-generation parent-child relationships, not the full cumulative split history that V3 requires. The migration uses:
+
+1. `EpochManager::get_shard_layout_history()` reconstructs all historical layouts by iterating through protocol versions (newest to oldest).
+2. `ShardLayoutV3::derive_with_layout_history()` processes this history via `build_shard_split_map()`, which extracts parent-child relationships from `windows(2)` of the layout sequence.
+3. The resulting V3 layout has full ancestor tracking and is ready for further dynamic splits.
+
+### Validation
+
+Both `proposed_split` and `shard_split` MUST be validated to prevent forging:
+
+- **Chunk header validation**: During state witness validation, the `proposed_split` in the received chunk header is compared against the locally-computed `ChunkExtra.proposed_split()`. A mismatch produces `InvalidChunkHeaderShardSplit`.
+- **Block header validation**: During block processing, the `shard_split` in the block header is recomputed by calling `get_upcoming_shard_split()` with the block's chunk headers. A mismatch produces `InvalidBlockHeaderShardSplit`.
+
+Because the split algorithm is deterministic and operates on state that is provable via state witnesses, all honest validators MUST arrive at the same split proposal for a given shard state.
+
+### Memtrie Pre-loading
+
+To ensure the parent shard's memtrie is available when resharding executes, a background pre-loading mechanism is used:
+
+1. **Epoch N, last block**: `shard_split` is embedded in the block header.
+2. **Epoch N → N+1 boundary**: `finalize_epoch()` creates EpochInfo for epoch N+2 with the new layout. `maybe_start_memtrie_preload_for_resharding()` detects the layout change and spawns a background thread to load the parent shard's memtrie from flat storage.
+3. **During epoch N+1**: The background load completes (typically a few minutes). On the next block's `postprocess_ready_block()`, the loaded memtrie is received, delta catch-up is applied, and it is inserted into the active memtries map.
+
+To preserve the flat state deltas needed for catch-up, the parent shard's `FlatStorage` flat head is held (paused) during background loading. Multiple subsystems (state snapshots, memtrie loading, resharding) can independently hold the flat head; it only advances once all holds are released.
+
+If the node restarts during the preparation epoch, the pending resharding is detected at startup and the parent shard is loaded synchronously.
+
+### New and Modified Data Structures
+
+This section lists data structures introduced or modified relative to [Resharding V3][NEP-568]:
+
+| Structure | Change | Description |
+|-----------|--------|-------------|
+| `ShardLayoutV3` | **New** | Shard layout with cumulative split history and ancestor maps (replaces `ShardLayoutV2`) |
+| `TrieSplit` | **New** | Split result: boundary account, left/right memory usage |
+| `DynamicReshardingConfig` | **New** | Resharding thresholds and limits |
+| `ShardLayoutConfig` | **New** | Enum: `Static` (legacy) or `Dynamic` |
+| `EpochInfoV5` | **New version** | Adds `shard_layout` and `last_resharding` fields |
+| `BlockHeaderInnerRestV6` | **New version** | Adds `shard_split: Option<(ShardId, AccountId)>` |
+| `ShardChunkHeaderInnerV5` | **New version** | Adds `proposed_split: Option<TrieSplit>` |
+| `BlockInfoV4` | **New version** | Adds `shard_split`, removes deprecated `slashed` map |
+| `ChunkExtraV5` | **New version** | Adds `proposed_split: Option<TrieSplit>` |
+
+#### ShardLayoutV3
+
+`ShardLayoutV2` (used by [Resharding V3][NEP-568]) stores only a single-generation split map: it records which parent shard was split into which children for the most recent resharding event. This is sufficient for manually scheduled, one-off resharding but breaks down with dynamic resharding, where repeated automatic splits create multi-generational parent-child chains.
+
+`ShardLayoutV3` replaces V2 with a layout that stores the **full cumulative split history**:
+
+- `shards_split_map: ShardsSplitMapV3` — records every split across all generations, not just the most recent one.
+- `shards_ancestor_map: ShardsAncestorMapV3` — enables O(1) lookup of all ancestors for any shard, which is needed for shard tracking (determining which current shards a node must track based on which historical shards it was assigned to).
+- `last_split: ShardId` — tracks the most recently split shard.
+
+This cumulative history is essential because dynamic resharding can produce long chains of splits (e.g., shard A → B,C → B,D,E → ...) and every node must be able to resolve any historical shard ID to its current descendants.
+
+### Data Flow Summary
+
+```
+[Chunk Application]
+    |
+    v
+compute_proposed_split() -- runtime checks memory thresholds, runs find_trie_split()
+    |
+    v
+[ChunkExtra.proposed_split] -- persisted in local storage
+    |
+    v
+[ShardChunkHeaderInnerV5.proposed_split] -- embedded in chunk header, broadcast to network
+    |
+    v
+[Block Production - last block of epoch]
+    |
+    v
+get_upcoming_shard_split() -- collects proposals from chunk headers, picks the best
+    |
+    v
+[BlockHeaderInnerRestV6.shard_split] -- embedded in block header
+    |
+    v
+[EpochManager::finalize_epoch()]
+    |
+    v
+next_next_shard_layout() -- derives ShardLayoutV3 for epoch N+2
+    |
+    v
+[EpochInfoV5.shard_layout] -- new layout stored in epoch info for epoch N+2
+```
+
+## Reference Implementation
+
+The implementation is gated behind the `ProtocolFeature::DynamicResharding` feature flag. Key code locations in `nearcore`:
+
+### Trie Split Algorithm
+
+- `core/store/src/trie/split.rs`: `find_trie_split`, `TrieDescent`, `find_mem_usage_split`, `best_split_at_current_path`
+- `core/primitives/src/trie_split.rs`: `TrieSplit` struct
+
+### Runtime Integration
+
+- `chain/chain/src/runtime/mod.rs`: `NightshadeRuntime::compute_proposed_split`, `check_dynamic_resharding`
+
+### Epoch Manager
+
+- `chain/epoch-manager/src/lib.rs`: `get_upcoming_shard_split`, `next_next_shard_layout`, `can_reshard`, `pick_shard_to_split`, `get_shard_layout`, `get_shard_layout_history`
+
+### Validation
+
+- `chain/chain/src/validate.rs`: `validate_chunk_with_chunk_extra_and_receipts_root` (chunk header validation), `validate_block_shard_split` (block header validation)
+
+### Memtrie Pre-loading
+
+- `chain/chain/src/chain.rs`: `maybe_start_memtrie_preload_for_resharding`, `postprocess_ready_block`
+- `core/store/src/trie/shard_tries.rs`: `spawn_background_memtrie_loading_for_shard`, `try_finalize_background_memtrie_loading`, `retain_memtries`
+- `core/store/src/trie/mem/loading.rs`: `apply_deltas_to_memtries`
+- `core/store/src/flat/storage.rs`: `hold_flat_head`, `release_flat_head_hold`
+
+### Shard Layout Derivation
+
+- `core/primitives/src/shard_layout/v3.rs`: `ShardLayoutV3::derive`, `ShardLayoutV3::derive_with_layout_history`, `build_shard_split_map`
+
+### Configuration
+
+- `core/primitives/src/epoch_manager.rs`: `DynamicReshardingConfig`, `ShardLayoutConfig`
+
+## Security Implications
+
+### Determinism of the Split Algorithm
+
+The split algorithm MUST be fully deterministic: given the same trie state, all validators MUST compute the same `TrieSplit`. This is guaranteed because:
+
+- `find_trie_split` operates on the committed trie state at a specific block height.
+- The algorithm uses only `memory_usage` values stored in trie nodes, which are part of the consensus state.
+- State witnesses include the trie nodes accessed during the split computation, allowing chunk validators to independently verify the result.
+
+A non-deterministic split algorithm would cause validators to disagree on the shard layout, leading to a chain fork.
+
+### Validation of Split Proposals
+
+Chunk producers could attempt to forge `proposed_split` values to manipulate which shard gets split or the boundary account. This is prevented by:
+
+1. Chunk validators recompute `proposed_split` from the state witness and reject mismatches (`InvalidChunkHeaderShardSplit`).
+2. Block validators recompute `shard_split` from the chunk headers in the block and reject mismatches (`InvalidBlockHeaderShardSplit`).
+
+### DoS via Threshold Manipulation
+
+An attacker could try to force unnecessary resharding by inflating a shard's state size. This is mitigated by:
+
+- The `min_child_memory_usage` threshold prevents splits that would create very small shards.
+- The `max_number_of_shards` cap prevents unbounded shard proliferation.
+- The `min_epochs_between_resharding` cooldown limits resharding frequency.
+- Storage staking costs make state inflation expensive.
+
+### Resource Consumption During Resharding
+
+Resharding requires additional memory (for hybrid memtries) and disk I/O (for flat state migration). The two-epoch delay ensures nodes have adequate preparation time. The `max_number_of_shards` parameter is used to size thread pools conservatively, preventing resource exhaustion from unexpected shard count increases.
+
+## Alternatives
+
+### Continue with Static Resharding
+
+The simplest alternative is to continue the V3 approach of manually scheduling resharding via protocol upgrades. This was rejected because it cannot scale with demand, requires significant operational overhead, and cannot react to sudden traffic changes. Each manual resharding takes weeks from analysis to deployment.
+
+### Dynamic Resharding Based on Gas Usage
+
+Instead of memory usage, gas (compute) utilization could drive resharding decisions. This was considered but deferred because:
+
+- Gas usage is more volatile and harder to threshold reliably.
+- Memory (state size) is the primary constraint for node operators (RAM for memtries).
+- Gas-based resharding could be added as a complementary signal in a future extension.
+
+### Shard Merging
+
+This NEP only supports splitting. Merging underutilized shards would allow the network to reclaim resources, but introduces significant additional complexity (reversing the split map, merging state tries, reassigning receipts). Merging is deferred to a future NEP as discussed in [Resharding V3's Future Possibilities][NEP-568].
+
+### Split Multiple Shards per Epoch
+
+Allowing more than one split per epoch was considered but rejected to limit the operational impact of resharding events and to simplify validation. The cooldown mechanism already allows tuning the resharding pace.
+
+## Future possibilities
+
+- **Gas-based split signals**: Augment the memory-based threshold with gas utilization metrics for more responsive scaling.
+- **Shard merging**: Combine underutilized shards with neighbors to free resources and reduce operational overhead.
+- **Multi-shard splits**: Allow splitting multiple shards in a single epoch when the network is under sustained heavy load.
+- **Boundary account adjustments**: Instead of splitting, move the boundary account between two adjacent shards to rebalance load without increasing shard count.
+
+## Consequences
+
+### Positive
+
+- The network can scale automatically in response to demand without protocol upgrades.
+- Eliminates the operational burden of manual shard layout analysis and deployment.
+- Reduces reaction time from weeks (manual protocol upgrade) to ~24 hours (two epochs on mainnet).
+- Fully compatible with stateless validation -- split proposals are verifiable through state witnesses.
+- Builds directly on the proven Resharding V3 execution machinery.
+
+### Neutral
+
+- The split algorithm performs a greedy descent that is equivalent to binary search on a monotonic cumulative distribution, so it finds the optimal boundary. However, a perfectly balanced split is not always achievable due to inherent constraints (indivisible accounts, minimum boundary length).
+- Thread pool sizes are based on `max_number_of_shards` rather than the current shard count, which is slightly wasteful but safe.
+
+### Negative
+
+- Additional computational cost during chunk application for shards near the epoch boundary (running the split algorithm).
+- Increased complexity in block/chunk header formats (new versioned structures).
+- Nodes must handle dynamically changing shard counts, which may complicate tooling and monitoring.
+
+### Backwards Compatibility
+
+Dynamic resharding is backwards compatible with existing protocol logic through the `ShardLayoutConfig` enum. When `ShardLayoutConfig::Static` is configured, the system behaves identically to Resharding V3. The transition to `ShardLayoutConfig::Dynamic` occurs as part of a protocol version upgrade that enables the `DynamicResharding` feature flag.
+
+The existing `ShardLayoutV2` used by Resharding V3 is automatically migrated to `ShardLayoutV3` when dynamic resharding is first enabled, via `ShardLayoutV3::derive_with_layout_history()`. Subsequent dynamic splits derive new V3 layouts from existing V3 layouts using `ShardLayoutV3::derive()`.
+
+External tooling that queries shard layouts via the `EXPERIMENTAL_protocol_config` RPC endpoint will continue to work. However, tools that cache shard layouts MUST re-query at epoch boundaries, as the layout may now change between epochs at the same protocol version.
+
+## Unresolved Issues
+
+- **Shard assignment stability across resharding**: Validator-to-shard assignment currently uses `ShardIndex`, so a resharding event that changes shard indices may cause excessive validator reassignment. The assignment algorithm should be made resharding-aware to minimize unnecessary churn.
+- **Shadow validation across resharding boundaries**: Shadow validation currently breaks at resharding boundaries.
+- **Fork network tooling**: The fork-network tool does not yet fully support dynamic resharding.
+- **SPICE integration**: Multiple integration points between the SPICE feature and resharding transitions remain incomplete (chunk executor, data distributor, chunk validation, chunk application).
+
+## Changelog
+
+### 1.0.0 - Initial Version
+
+> Placeholder for the context about when and who approved this NEP version.
+
+#### Benefits
+
+> List of benefits filled by the Subject Matter Experts while reviewing this version:
+
+- Benefit 1
+- Benefit 2
+
+#### Concerns
+
+> Template for Subject Matter Experts review for this version:
+> Status: New | Ongoing | Resolved
+
+|   # | Concern | Resolution | Status |
+| --: | :------ | :--------- | -----: |
+|   1 |         |            |        |
+|   2 |         |            |        |
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+
+<!-- links -->
+
+[NEP-508]: https://github.com/near/NEPs/blob/master/neps/nep-0508.md
+[NEP-568]: https://github.com/near/NEPs/blob/master/neps/nep-0568.md

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -109,13 +109,13 @@ When `ShardLayoutConfig::Dynamic` is active, the shard layout is stored in `Epoc
 
 Updating any value therefore requires a protocol upgrade: a new protocol version is added with a new epoch config JSON file, and the network adopts the change once enough nodes vote to upgrade. This is intentional -- thresholds and limits affect consensus (every validator must agree on whether a split should be proposed), so they MUST be uniform across the network. Initial mainnet values will be set conservatively (see [Limiting the Blast Radius](#limiting-the-blast-radius)) and tuned through subsequent protocol upgrades as operational experience accumulates.
 
-With dynamic resharding, per-shard default cache sizes are no longer derived from the protocol version, since the shard layout is not known at compile time. Nodes use uniform default cache sizes across all shards. Performance testing on mainnet state has shown no significant impact from this change. Node operators can still override cache sizes via manual configuration if needed.
+With dynamic resharding, per-shard default sizes for the **trie cache** (the RocksDB-side trie-storage cache configured via `per_shard_max_bytes` in `trie_cache_config`, see `core/store/src/config.rs`) are no longer derived from the protocol version, since the shard layout is not known at compile time. Nodes use uniform default cache sizes across all shards. Performance testing on mainnet state has shown no significant impact from this change. Node operators can still override cache sizes via manual configuration if needed. Note that per-shard cache overrides are keyed by `ShardUId`, and new child shards are assigned fresh shard IDs at split time that operators cannot pre-declare in config -- RPC nodes that rely on tuned per-shard cache sizes will use the default for the new shards until the operator updates configuration after the split. Validators run on memtries and are not affected; the consideration is RPC-side only and may affect query latency for the new shards in the short term.
 
 ### Limiting the Blast Radius
 
 When dynamic resharding is first released on mainnet, `max_number_of_shards` will be set to one more than the current shard count. This caps the damage from any single resharding event: at most one new shard can be created before further splits are blocked, regardless of memory thresholds. Successive protocol upgrades will raise the limit gradually as confidence in the feature grows. With this conservative rollout, in practice we expect that disabling dynamic resharding will never be necessary -- the shard limit itself acts as the safety mechanism.
 
-In the unlikely event that the shard limit proves insufficient (for instance, a previously-allowed split turns out to be problematic and we want to prevent any further splits while we investigate), an emergency mitigation is to ship a protocol upgrade that sets `block_split_shards` to include every existing shard ID. This blocks all further splits while leaving the rest of the protocol unchanged. We note, however, that if a protocol upgrade is needed anyway, it is generally preferable to use that upgrade to fix the underlying issue rather than to disable resharding.
+In the unlikely event that the shard limit proves insufficient (for instance, a previously-allowed split turns out to be problematic and we want to prevent any further splits while we investigate), the **only** mitigation is to ship a protocol upgrade that sets `block_split_shards` to include every existing shard ID. This blocks all further splits while leaving the rest of the protocol unchanged. Note that a protocol upgrade typically takes 1-2 weeks from decision to network activation, so this is not a fast lever -- the `max_number_of_shards` cap is therefore the load-bearing safety mechanism in the short term, since if a split goes wrong there is no faster recourse. We also note that if a protocol upgrade is needed anyway, it is generally preferable to use that upgrade to fix the underlying issue rather than to disable resharding.
 
 ### Finding the Optimal Split Point
 
@@ -162,7 +162,7 @@ The algorithm performs a greedy binary-search-like traversal, descending through
 
 The resulting boundary account MUST satisfy NEAR's existing account ID validity rules (minimum 2 characters, valid UTF-8). If the natural descent terminates too early to produce a valid account ID, the algorithm force-descends into the first available child until the minimum path length is met.
 
-The algorithm works with both in-memory tries (memtries) and disk-based tries, and is deterministic and reproducible from state witnesses (recorded trie storage), which is critical for stateless validation.
+The algorithm works with both in-memory tries (memtries) and disk-based tries, and is deterministic and reproducible from state witnesses (recorded trie storage), which is critical for stateless validation. The exact protocol behavior -- including force-descent on odd-nibble paths, the middle-child fallback when no child crosses the threshold, and boundary inclusion semantics (left-excludes / right-includes the boundary account) -- is defined by the reference implementation at `core/store/src/trie/split.rs`.
 
 ### Proposing a Shard Split
 
@@ -208,10 +208,10 @@ Only the last block of each epoch MAY carry a non-None `shard_split`.
 During `EpochManager::finalize_epoch()`, when finalizing epoch N:
 
 1. Read `block_info.shard_split()` from the last block of epoch N.
-2. Call `next_next_shard_layout()`, which has three phases:
-   - **Static fallback**: If the next-next epoch config specifies a static layout, use it (backward compatibility).
-   - **Transitional**: If the current epoch doesn't have dynamic resharding enabled, carry forward the existing layout.
-   - **Dynamic**: If a split is present, derive a new `ShardLayoutV3` from the current layout. New shard IDs are assigned as `max(existing_shard_ids) + 1` and `max(existing_shard_ids) + 2`.
+2. Call `next_next_shard_layout()`, which selects one of three phases based on the configuration of the current and next-next epoch:
+   - **Static fallback**: When the next-next epoch config still has `ShardLayoutConfig::Static`. Returns the static layout. Used for legacy / manually-scheduled resharding and for tests.
+   - **Transitional**: When the next-next epoch is the first to have `ShardLayoutConfig::Dynamic` and the current epoch is still `Static`. A fresh `ShardLayoutV3` is derived from the previous layout's history via `derive_with_layout_history()`. This phase runs **exactly once**, at the protocol upgrade that enables dynamic resharding (see [Migration from Static to Dynamic Resharding](#migration-from-static-to-dynamic-resharding)).
+   - **Dynamic**: When both the current and next-next epochs are under `ShardLayoutConfig::Dynamic`. The selected `shard_split` decision is applied via `ShardLayoutV3::derive()`. New shard IDs are assigned as `max(existing_shard_ids) + 1` and `max(existing_shard_ids) + 2`.
 3. **Stale-split guard**: If `shard_split` references a shard that no longer exists in the next layout (e.g. it was already split in a previous epoch via a static-layout protocol upgrade), the split is skipped and the next layout is carried forward unchanged. This prevents inconsistencies when a static and dynamic split happen to target the same shard in adjacent epochs.
 4. Store the resulting layout in `EpochInfoV5.shard_layout` for epoch N+2.
 
@@ -224,6 +224,8 @@ When the network first enables dynamic resharding, the current shard layout (`Sh
 1. `EpochManager::get_shard_layout_history()` reconstructs all historical layouts by iterating through protocol versions (newest to oldest).
 2. `ShardLayoutV3::derive_with_layout_history()` processes this history via `build_shard_split_map()`, which extracts parent-child relationships from `windows(2)` of the layout sequence.
 3. The resulting V3 layout has full ancestor tracking and is ready for further dynamic splits.
+
+This migration path runs **exactly once**, at the protocol upgrade that enables dynamic resharding. From that point on, every subsequent split derives the new layout from the existing V3 layout via `ShardLayoutV3::derive()`; `derive_with_layout_history()` is not called again.
 
 ### Validation
 
@@ -244,7 +246,31 @@ To ensure the parent shard's memtrie is available when resharding executes, a ba
 
 To preserve the flat state deltas needed for catch-up, the parent shard's `FlatStorage` flat head is held (paused) during background loading. Multiple subsystems (state snapshots, memtrie loading, resharding) can independently hold the flat head; it only advances once all holds are released.
 
-If the node restarts during the preparation epoch, the pending resharding is detected at startup and the parent shard is loaded synchronously.
+If the node restarts during the preparation epoch, the pending resharding is detected at startup and the parent shard is loaded synchronously (for shards the node currently tracks).
+
+### State Sync Across Resharding Boundaries
+
+A node that falls behind across a resharding boundary needs to acquire state for the new shard layout. The existing state-sync machinery handles this without protocol changes specific to dynamic resharding:
+
+- **Pending-layout detection**: On startup or while catching up, the node uses `EpochManagerAdapter::get_resharding_parent_shard_uid()` to determine whether the current epoch's layout differs from the next, and if so identifies the parent shard whose memtrie must be loaded. The catchup path triggers a synchronous parent-memtrie load via `load_memtrie_on_catchup()`.
+- **Cross-shard receipts**: Receipts addressed to the parent shard remain available across the resharding boundary because the incoming-receipts fetch uses `ReceiptFilter::All`. Shard-membership filtering happens after the Merkle proof is verified, so children correctly pick up receipts that were originally addressed to their parent.
+- **State download point**: The standard state-sync behavior (downloading state for the current epoch's shards, then applying chunks until caught up) operates on the post-resharding shard layout when the node is catching up past a boundary, so no special-case logic is needed at the sync-protocol level.
+
+### Sticky Validator Assignment Across Resharding
+
+Without special handling, every shard layout change causes the chunk-producer-to-shard assignment to be reshuffled, because the legacy assignment is keyed by `ShardIndex` (a contiguous index that changes when shards are split). Reshuffling on every resharding event would trigger network-wide state-sync activity as validators pick up shards they were not previously tracking -- impractical at any meaningful resharding frequency.
+
+The companion protocol feature `StickyReshardingValidatorAssignment` resolves this by introducing an `AssignmentStrategy` enum with three variants (see `chain/epoch-manager/src/shard_assignment/mod.rs`):
+
+- **`CarryOver`**: Used when the shard layout is unchanged across the boundary. Validators keep their assignments by `ShardIndex`.
+- **`StickyResharding`**: Used across a resharding event. Unchanged shards keep their validators by `ShardId`; the children of a split shard inherit a stake-balanced subset of the parent shard's validators via greedy bin-packing. This minimizes the number of validators that need to start tracking a new shard.
+- **`Fresh`**: Fallback path when the feature is not enabled or when sticky construction fails (e.g., synthetic test layouts that aren't derived from the previous layout). Assignment starts from scratch.
+
+The `StickyResharding` strategy also raises the per-epoch `chunk_producer_assignment_changes_limit`, so freshly split children reach their target validator count in a single epoch rather than over many.
+
+**Independence and release strategy.** `StickyReshardingValidatorAssignment` is technically a separate protocol feature: it could be enabled with the existing (static) resharding mechanism, and dynamic resharding could in principle be enabled without it. However, dynamic resharding without sticky assignment would produce the state-sync stampede described above on every split, which is not operationally acceptable. The two features will therefore be **stabilized and released together** in the same protocol version, even though they have independent feature flags.
+
+**Failure modes.** Sticky assignment affects only validator availability, not consensus: a misassignment results in missed chunks and possible validator kickouts, but does not cause validators to disagree on the chain. If sticky construction fails for an unexpected layout, the fallback to `Fresh` ensures the network can still produce blocks.
 
 ### New and Modified Data Structures
 
@@ -266,13 +292,15 @@ This section lists data structures introduced or modified relative to [Reshardin
 
 `ShardLayoutV2` (used by [Resharding V3][NEP-568]) stores only a single-generation split map: it records which parent shard was split into which children for the most recent resharding event. This is sufficient for manually scheduled, one-off resharding but breaks down with dynamic resharding, where repeated automatic splits create multi-generational parent-child chains.
 
-`ShardLayoutV3` replaces V2 with a layout that stores the **full cumulative split history**:
+`ShardLayoutV3` replaces V2 with a layout that stores the **cumulative split history from V2 onward**:
 
 - `shards_split_map: ShardsSplitMapV3` — records every split across all generations, not just the most recent one.
 - `shards_ancestor_map: ShardsAncestorMapV3` — enables O(log N) lookup of all ancestors for any shard (it is a `BTreeMap<ShardId, Vec<ShardId>>`), which is needed for shard tracking (determining which current shards a node must track based on which historical shards it was assigned to).
 - `last_split: ShardId` — tracks the most recently split shard.
 
 This cumulative history is essential because dynamic resharding can produce long chains of splits (e.g., shard A → B,C → B,D,E → ...) and every node must be able to resolve any historical shard ID to its current descendants.
+
+Note that `build_shard_split_map()` walks the layout history via `windows(2)` and only consumes V2+ entries when reconstructing parent-child relationships. V1 predates the parent-child split map and has no split relationships to track, so V1 layouts contribute no entries to the reconstructed history. In practice, the resulting V3 layout therefore tracks the history of every split that ever occurred since V2 was introduced -- which covers every actual resharding event on mainnet.
 
 ### Data Flow Summary
 
@@ -369,7 +397,7 @@ An attacker could try to force unnecessary resharding by inflating a shard's sta
 - The `min_child_memory_usage` threshold prevents splits that would create very small shards.
 - The `max_number_of_shards` cap prevents unbounded shard proliferation.
 - The `min_epochs_between_resharding` cooldown limits resharding frequency.
-- Storage staking costs make state inflation expensive.
+- Storage staking costs make state inflation expensive. Note that storage staking *locks* NEAR rather than burning it -- an attacker who inflates state can release the locked stake by deleting the state after the attack. The effective cost to the attacker is therefore the opportunity cost of the locked stake over the inflation period, not the full storage-staking price.
 
 ### Resource Consumption During Resharding
 
@@ -428,7 +456,7 @@ Allowing more than one split per epoch was considered but rejected to limit the 
 
 - The split algorithm performs a greedy descent that is equivalent to binary search on a monotonic cumulative distribution, so it finds the optimal boundary. However, a perfectly balanced split is not always achievable due to inherent constraints (indivisible accounts, minimum boundary length).
 - Thread pool sizes are based on `max_number_of_shards` rather than the current shard count, which is slightly wasteful but safe.
-- Mainnet and testnet shard layouts will diverge, since splits are driven by actual state size which differs between the two networks. This is expected and by design, but means tooling and tests cannot assume a fixed shard layout for either network.
+- Mainnet and testnet shard layouts will diverge over time, since splits are driven by actual state size which differs between the two networks. This is expected and by design. External tooling SHOULD always query the `shard_layout` for the relevant epoch via the `EXPERIMENTAL_protocol_config` RPC endpoint rather than caching the layout statically. Indexers and other consumers that expose per-shard arrays (e.g. `IndexerShard`) keyed by array position will break when new shards appear; consumers should key by `shard_id` rather than by array index.
 
 ### Negative
 
@@ -443,6 +471,8 @@ Dynamic resharding is backwards compatible with existing protocol logic through 
 The existing `ShardLayoutV2` used by Resharding V3 is automatically migrated to `ShardLayoutV3` when dynamic resharding is first enabled, via `ShardLayoutV3::derive_with_layout_history()`. Subsequent dynamic splits derive new V3 layouts from existing V3 layouts using `ShardLayoutV3::derive()`.
 
 External tooling that queries shard layouts via the `EXPERIMENTAL_protocol_config` RPC endpoint will continue to work. However, tools that cache shard layouts MUST re-query at epoch boundaries, as the layout may now change between epochs at the same protocol version.
+
+A naming-collision caveat for RPC consumers: `ProtocolConfigView` already exposes a `dynamic_resharding: bool` field, which is a legacy genesis flag unrelated to this NEP and is set to `false` in all current configurations. RPC clients that read this boolean to detect dynamic resharding will get a misleading signal. The authoritative source for whether dynamic resharding is active is the `ShardLayoutConfig` (carried via `EpochInfo`'s `shard_layout_config`) being of variant `Dynamic` -- not the legacy bool.
 
 ## Unresolved Issues
 

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -77,10 +77,13 @@ pub struct DynamicReshardingConfig {
     pub max_number_of_shards: NumShards,
 
     /// Minimum epochs between consecutive resharding events.
-    /// A value of 0 allows resharding every epoch (gap of 1 epoch between
-    /// effective layouts); a value of N enforces a gap of at least N+1 epochs
-    /// between effective layouts.
-    pub min_epochs_between_resharding: EpochHeight,
+    /// Must be greater than `0`: allowing back-to-back reshardings is unsafe
+    /// because a child shard would inherit `proposed_split` from its parent's
+    /// final chunk while the child's first chunk freshly computes
+    /// `proposed_split = None`, producing an `InvalidChunkHeaderShardSplit`
+    /// mismatch. A value of `N` enforces a gap of at least `N+1` epochs between
+    /// effective layouts.
+    pub min_epochs_between_resharding: NonZeroEpochHeight,
 
     /// Shards to force-split regardless of memory thresholds.
     pub force_split_shards: Vec<ShardId>,
@@ -186,7 +189,7 @@ When a chunk is missing in a block, the previous chunk header for that shard is 
 - If the shard had at least one chunk produced within the "possibly-last-block" window, its `proposed_split` is valid (the shard's state cannot change while its chunks are missing) and is correctly carried forward through the missing-chunk headers. The shard is considered normally for selection.
 - If the shard's last produced chunk predates that window, its `proposed_split` is `None` (the proposal is only computed near the epoch boundary). The shard is silently skipped this epoch and will be reconsidered in the next.
 
-A subtle consequence of the second case: if multiple shards are above the split threshold and the **largest** one is the one whose chunks went missing during the window, its `None` excludes it from the picker and a smaller-but-eligible shard gets picked instead. The split of the larger shard is then delayed by at least one epoch (and longer if `min_epochs_between_resharding > 0`, since the cooldown will apply to the smaller shard's split that just occurred). The split chosen is still legitimate (the smaller shard is above threshold by construction), so this is a degradation in priority, not in correctness.
+A subtle consequence of the second case: if multiple shards are above the split threshold and the **largest** one is the one whose chunks went missing during the window, its `None` excludes it from the picker and a smaller-but-eligible shard gets picked instead. The split of the larger shard is then delayed by at least `min_epochs_between_resharding + 1` epochs (the cooldown applies to the smaller shard's split that just occurred). The split chosen is still legitimate (the smaller shard is above threshold by construction), so this is a degradation in priority, not in correctness.
 
 In all cases, correctness is preserved: chunk-header validation compares `proposed_split` against the matching `ChunkExtra` from when the chunk was applied, and these agree by construction. Missing chunks can only delay or substitute a split, never produce an incorrect one.
 

--- a/neps/nep-0639.md
+++ b/neps/nep-0639.md
@@ -198,7 +198,7 @@ At the last block of each epoch, the block producer:
 2. Calls `get_upcoming_shard_split()`, which:
    - Verifies dynamic resharding is enabled (via `ShardLayoutConfig::Dynamic`).
    - Checks the resharding cooldown: `epoch_height - last_resharding >= min_epochs_between_resharding`.
-   - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority; otherwise the shard with the highest `total_memory()` wins. In the (extremely unlikely in production, but possible in tests) case of a tie, the shard with the highest `ShardId` wins -- the selection key is the tuple `(total_memory, shard_id)`, ensuring determinism.
+   - Calls `pick_shard_to_split()` to select the winning shard: forced shards have priority; otherwise the shard with the highest `total_memory()` wins. In the (extremely unlikely in production, but possible in tests) case of a tie, the shard with the highest `ShardId` wins -- the selection key is the tuple `(total_memory, shard_id)`, ensuring determinism. When multiple shards appear in `force_split_shards`, the first entry (by declaration order in the config `Vec`) for which a `proposed_split` exists is chosen, regardless of memory usage.
 3. Embeds the result as `shard_split: Option<(ShardId, AccountId)>` in `BlockHeaderInnerRestV6`.
 
 Only the last block of each epoch MAY carry a non-None `shard_split`.
@@ -236,17 +236,25 @@ Both `proposed_split` and `shard_split` MUST be validated to prevent forging:
 
 Because the split algorithm is deterministic and operates on state that is provable via state witnesses, all honest validators MUST arrive at the same split proposal for a given shard state.
 
+#### Behavior on Forks
+
+A `shard_split` value in a block header is provisional until that block is finalized. In the presence of forks at the epoch boundary, multiple candidate "last blocks of epoch N" may exist on competing branches -- each may carry its own (self-consistent) `shard_split` value, possibly for different shards or one `None` / one `Some`. Each branch independently triggers the post-processing actions described below (memtrie pre-load, resharding scheduling). Once Doomslug finality canonicalizes one branch, the losing branch's layout decision is reorged out of the chain state. Any memtries loaded for a shard that the validator no longer needs in the canonical view are dropped at the next `retain_memtries` call, which runs at the epoch boundary. Correctness is preserved at all times; operators may observe transient "phantom" pre-load activity on losing branches as expected behavior, not a bug.
+
 ### Memtrie Pre-loading
 
 To ensure the parent shard's memtrie is available when resharding executes, a background pre-loading mechanism is used:
 
 1. **Epoch N, last block**: `shard_split` is embedded in the block header.
 2. **Epoch N → N+1 boundary**: `finalize_epoch()` creates EpochInfo for epoch N+2 with the new layout. `maybe_start_memtrie_preload_for_resharding()` detects the layout change and spawns a background thread to load the parent shard's memtrie from flat storage.
-3. **During epoch N+1**: The background load completes (typically a few minutes). On the next block's `postprocess_ready_block()`, the loaded memtrie is received, delta catch-up is applied, and it is inserted into the active memtries map.
+3. **During epoch N+1**: The background load completes (typically takes up to 30 minutes for the largest shards on mainnet, depending on hardware). On the next block's `postprocess_ready_block()`, the loaded memtrie is received, delta catch-up is applied, and it is inserted into the active memtries map.
 
 To preserve the flat state deltas needed for catch-up, the parent shard's `FlatStorage` flat head is held (paused) during background loading. Multiple subsystems (state snapshots, memtrie loading, resharding) can independently hold the flat head; it only advances once all holds are released.
 
-If the node restarts during the preparation epoch, the pending resharding is detected at startup and the parent shard is loaded synchronously (for shards the node currently tracks).
+The background load is **single-threaded by design**: `load_trie_from_flat_state_and_delta` is called with `parallelize: false` so that the loading work does not contend for CPU with block production and validation in the same node. This is the dominant reason the wall-clock is measured in tens of minutes for large shards rather than seconds.
+
+The pre-load **bypasses operator memtrie configuration**: `maybe_start_memtrie_preload_for_resharding` does not consult `load_memtries_for_shards` or `load_memtries_for_tracked_shards` from the node's trie config. A node that has explicitly disabled memtries for a shard will still have one loaded during the resharding preparation window, because the resharding logic requires the parent memtrie to execute the split.
+
+If the node restarts during the preparation epoch, the pending resharding is detected at startup and the parent shard is loaded synchronously, but only for shards the node currently tracks (the load is gated by the validator's `tracked_shards` set; the resharding-pending exception bypasses the memtrie-config filter but not the tracked-shards filter).
 
 ### State Sync Across Resharding Boundaries
 


### PR DESCRIPTION
This proposal introduces dynamic resharding: a protocol-level mechanism that enables automatic splitting of shards based on their state size, without requiring a protocol upgrade. It replaces the static approach used by Resharding V2 (`NEP-508`) and Resharding V3 (`NEP-568`), where shard layout changes were hardcoded into specific protocol versions and required coordinated binary releases.