### PR TITLE
NEP-642: Account cost increase

### DIFF
--- a/neps/nep-0642.md
+++ b/neps/nep-0642.md
@@ -1,0 +1,336 @@
+---
+NEP: 642
+Title: Account cost increase
+Authors: Jan Malinowski <jan.ciolek@nearone.org>
+Status: New
+DiscussionsTo: https://github.com/nearprotocol/neps/pull/642
+Type: Protocol
+Version: 1.0.0
+Created: 2026-06-08
+LastUpdated: 2026-06-08
+---
+
+<!-- NEP Header Preamble
+
+Each NEP must begin with an RFC 822 style header preamble. The headers must appear in the following order:
+
+NEP: The NEP title in no more than 4-5 words.
+
+Title: NEP title
+
+Author: List of author name(s) and optional contact info. Examples FirstName LastName <satoshi@fakenews.org>, FirstName LastName (@GitHubUserName)>
+
+Status: The NEP status -- New | Approved | Deprecated.
+
+DiscussionsTo (Optional): URL of current canonical discussion thread, e.g. GitHub Pull Request link.
+
+Type: The NEP type -- Protocol | Contract Standard | Wallet Standard | DevTools Standard.
+
+Requires (Optional): NEPs may have a Requires header, indicating the NEP numbers that this NEP depends on.
+
+Replaces (Optional): A newer NEP marked with a SupercededBy header must have a Replaces header containing the number of the NEP that it rendered obsolete.
+
+SupersededBy (Optional): NEPs may also have a SupersededBy header indicating that a NEP has been rendered obsolete by a later document; the value is the number of the NEP that replaces the current document.
+
+Version: The version number. A new NEP should start with 1.0.0, and future NEP Extensions must follow Semantic Versioning.
+
+Created: The Created header records the date that the NEP was assigned a number, should be in ISO 8601 yyyy-mm-dd format, e.g. 2022-12-31.
+
+LastUpdated: The Created header records the date that the NEP was assigned a number, should be in ISO 8601 yyyy-mm-dd format, e.g. 2022-12-31.
+
+See example above -->
+
+## Summary
+
+This proposal makes creating a new account on NEAR roughly 10x more expensive than it is today. The cost of other operations remains unchanged.
+
+This is needed to bring the cost of storage taken up by the account in line with the cost of storage paid for with storage deposits. Currently the storage taken up by new accounts is cheaper than storage purchased with storage deposits, which makes for an unfair balance.
+
+The cost increase will be achieved by increasing the upfront gas purchase price 10x. For creating an account we will charge the full 10x gas price. For other operations we will charge a lower price and refund the difference, so that the final cost remains unchanged.
+
+## Motivation
+
+Every account that exists on NEAR takes up permanent state that every node tracking the shard must store indefinitely. NEAR already accounts for the ongoing cost of state through [storage staking](https://docs.near.org/protocol/storage/storage-staking): an account must lock NEAR proportional to the bytes it occupies (currently `1 NEAR` per `100 KB`). A single account can take up to 770 bytes of storage without paying any storage deposits (zero balance account), which should cost `0.0077 NEAR` at the price used in storage deposits.
+
+The fee charged for creating that account, however, has been disconnected from this cost. The `create_account` action fee is ~7.7 Tgas, which at the network minimum gas price (`0.0001 NEAR/TGas`) costs `0.00077 NEAR`. Because the network almost always runs at the minimum gas price, account creation has effectively been an order of magnitude cheaper than the normal storage cost. This pricing imbalance is not ideal, storing data should cost the same, no matter where the bytes come from.
+
+## Specification
+
+The general idea is that the gas will be purchased at a price that is 10x higher than the current minimum gas price. For operations that don't create an account the runtime will charge the normal gas price and refund the difference, so the final cost remains unchanged. For operations that create an account the runtime will charge more to cover the proper cost of creating the account.
+
+All behavior described here is gated behind a new protocol feature and only takes effect from the protocol version in which it is activated.
+
+### New runtime parameters
+
+The proposal adds two runtime configuration parameters and changes how gas attached to a receipt is priced and refunded. 
+
+| Parameter | Value | Meaning |
+| :-- | :-- | :-- |
+| `min_gas_purchase_price` | `0.001 NEAR/TGas` | Minimum price at which the gas attached to a receipt is *purchased*. This is 10x the network minimum gas price of `0.0001 NEAR/TGas`. |
+| `account_creation_charge` | `0.007 NEAR` | Fixed amount burned when a new account is created. |
+
+In addition, the `create_account` and `deterministic_state_init` action fees are rebalanced. Their total gas is unchanged; weight is only shifted from the *send* cost to the *execution* cost so that enough gas is burned during execution to fund the charge (see below).
+
+| Action | Field | Old | New |
+| :-- | :-- | --: | --: |
+| `create_account` | send (sir / not-sir) | 3.85 Tgas | 0.5 Tgas |
+| `create_account` | execution | 3.85 Tgas | 7.2 Tgas |
+| `deterministic_state_init` | send (sir / not-sir) | 3.85 Tgas | 0.5 Tgas |
+| `deterministic_state_init` | execution | 4.08 Tgas | 7.43 Tgas |
+
+### Purchase price vs. burn price
+
+Before this change, the gas attached to a receipt was purchased and burned at the same price. This NEP decouples the two:
+
+* **Purchase price** - the price the signer pays upfront for the gas attached to a receipt. It is equal to `max(current_gas_price, min_gas_purchase_price)`.
+* **Burn price** - the price at which gas is actually burned while executing the receipt. It is `min(gas_purchase_price, current_gas_price)`, i.e. it never exceeds the purchase price.
+
+This is similar to "pessimistic gas pricing" that NEAR had in the past.
+
+Because the purchase price is at least `min_gas_purchase_price` (10x the minimum), while gas is usually burned at the much lower current price, every receipt accrues a **price surplus**:
+
+```
+price_surplus = (gas_purchase_price - gas_burn_price) * gas_burnt
+```
+
+For an ordinary transaction this surplus is refunded to the signer. The net economic cost of a non-account-creating transaction is therefore unchanged - the user simply has to provide more NEAR upfront and receives the difference back. The only observable differences are the higher upfront balance requirement and one extra refund receipt per receipt that was purchased above its burn price.
+
+When converting a transaction to a receipt the gas is purchased and burned at the normal price (burn price). Only the gas attached to the receipt is purchased at a higher price.
+
+
+The burn price is never larger than the purchase price (gas_deficit is always 0). This makes things easier to reason about and is in line with the current stable version.
+
+There are some use cases where contract authors assume that each function call increases the balance by some amount, and that increases the available storage deposit. If we tried to reduce the reward to cover for the deficit it might break those contracts. It's best to keep the deficit at zero.
+
+Contract rewards are calculated at the burn price (30% of the gas burned by FunctionCall actions is converted to NEAR at the burn price and transferred to the contract owner).
+
+### Charging for account creation
+
+When applying a receipt that successfully creates a new account, the protocol burns a portion of the price surplus instead of refunding all of it, so that the total cost of creating the account reaches `account_creation_charge`:
+
+```
+desired_cost        = account_creation_charge                       # 0.007 NEAR
+create_account_gas  = create_account.execution fee gas              # 7.2 Tgas
+burned_cost         = gas_burn_price * create_account_gas           # already burned during execution
+amount_to_charge    = max(0, desired_cost - burned_cost)            # top-up taken from the surplus
+```
+
+`amount_to_charge` is then subtracted from the refund and burned. The total cost of creating an account is therefore `max(desired_cost, burned_cost)`:
+
+* At low (typical) gas prices, `burned_cost` is small, the top-up brings the total up to the fixed `0.007 NEAR`.
+* At high gas prices, the naturally-burned gas already exceeds `0.007 NEAR`, no top-up is taken, and the user simply pays the (higher) gas cost.
+
+This applies regardless of *how* the account is created - an explicit `CreateAccount` action, implicit account creation by transferring to a not-yet-existing implicit account, a `DeterministicStateInit` action, or an account created by a contract through a cross-contract call. Because the receipt that creates the account is not known to be account-creating at the time its gas is purchased, all receipts must purchase gas at `min_gas_purchase_price`; the charge is only taken from the surplus of receipts that actually create an account.
+
+### Invariant
+
+The mechanism relies on there always being enough surplus to cover the charge. This is guaranteed by the invariant:
+
+```
+min_gas_purchase_price * create_account.execution_gas >= account_creation_charge
+```
+
+With the proposed values: `0.001 NEAR/TGas * 7.2 TGas = 0.0072 NEAR >= 0.007 NEAR`. As long as a receipt's gas was purchased at a price of at least `min_gas_purchase_price`, the surplus on the burned `create_account` execution gas is always sufficient to fund the full charge.
+
+For this to hold, the account-creating receipt must burn at least `create_account.execution_gas`, so that there is enough surplus on that burned gas to skim the charge from. This holds for every account-creation path, not just an explicit `CreateAccount` action:
+
+* Implicit and ETH-implicit accounts are created by a `Transfer` to a not-yet-existing implicit address. In these cases the transfer execution fee already includes the `create_account` execution fee (see `transfer_exec_fee` in `core/parameters/src/cost.rs`): for an ETH-implicit account it is `transfer + create_account`, and for a NEAR-implicit account it is `transfer + create_account + add_full_access_key`. So the account-creating receipt burns at least `create_account.execution_gas` in both cases.
+* `DeterministicStateInit` (and deterministic accounts created via `Transfer`) likewise burn at least the `create_account` execution fee — its own execution fee (`7.43 Tgas`) is even higher.
+
+Because the charge calculation always references `create_account.execution_gas` and every creation path burns at least that much, the account creation charge is fully funded no matter how the account came to exist.
+
+This invariant is also why `account_creation_charge` is `0.007 NEAR` rather than the `0.0077 NEAR` cost of a zero-balance account derived in the motivation. With `7.2 TGas` being burned on the execution side, we can charge at most `0.0072 NEAR` for the new account. To charge `0.0077 NEAR` we would have to move all of the gas to the execution side (`send: 0 TGas, exec: 7.7 TGas`) or further increase the purchase gas price. We can't really set the send cost to zero, as it would allow for abusive behavior. `0.007 NEAR` is close enough to the desired `0.0077 NEAR`. The cost has to be charged on the execution side, as that's where the runtime sees if the receipt created a new account or not.
+
+Receipts created in older protocol versions might have purchased gas at a price that is insufficient to cover the new account creation charge. For such receipts we charge as much as possible from the burned gas refund.
+
+### Examples
+
+Here are a few examples to make things clearer. The numbers in these examples might not be 100% exact, but they give an idea of how things work.
+
+#### Simple FunctionCall
+
+Let's imagine a simple transaction with a single FunctionCall action. The user attaches 100 TGas to the receipt, and the function call burns 50 TGas during execution.
+
+Previously:
+* `gas_price = 0.0001 NEAR/TGas`
+* User purchases `100 TGas` for `0.01 NEAR`
+* The receipt burns `50 TGas`
+* There's `50 TGas` of unused gas, which generates a refund
+* The refund is equal to `50 TGas * 0.0001 NEAR/TGas = 0.005 NEAR`
+* The final cost is `0.005 NEAR`
+
+After the change:
+* `gas_price = 0.0001 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
+* `purchase_price = 0.001 NEAR/TGas`
+* User purchases `100 TGas` for `0.1 NEAR` (buying at the purchase price)
+* The receipt burns `50 TGas` at the burn price (`gas_price = 0.0001 NEAR/TGas`)
+* The 50 TGas of burned gas was purchased at `purchase_price`, but burned at a lower `burn_price`. This generates a refund to make up for the price difference.
+* Price difference refund is equal to `(purchase_price - burn_price) * 50 TGas = 0.045 NEAR`
+* There's `50 TGas` of unused gas, which generates a refund using the purchase price `(50 TGas * 0.001 NEAR/TGas = 0.05 NEAR)`
+* The total refund is `0.045 NEAR + 0.05 NEAR = 0.095 NEAR`
+* The final cost is `0.005 NEAR`, same as before
+
+#### CreateAccount + FunctionCall
+
+Now let's take a transaction which creates an account and runs a FunctionCall action (actions: `[CreateAccount, FunctionCall]`). The user attaches 100 TGas to the receipt, the function call burns 50 TGas during execution. We will omit the base transaction cost and the send costs of the `FunctionCall` action for simplicity, they're the same in both cases.
+
+Previously:
+* `gas_price = 0.0001 NEAR/TGas`
+* User pays `3.85 TGas` to send the `CreateAccount` action, costing `0.000385 NEAR`
+* User purchases `100 TGas` for `0.01 NEAR` and attaches it to the receipt
+* Executing the create account actions burns `3.85 TGas`
+* The FunctionCall action burns `50 TGas`
+* There's `46.15 TGas` of unused gas, which generates a refund
+* The refund is equal to `46.15 TGas * 0.0001 NEAR/TGas = 0.004615 NEAR`
+* The final cost is `0.000385 + 0.01 - 0.004615 = 0.00577 NEAR`
+
+Notice that the final cost is `0.00077 NEAR` higher than the previous example, which means that creating an account costs `0.00077 NEAR`.
+
+After the change:
+* `gas_price = 0.0001 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
+* `purchase_price = 0.001 NEAR/TGas`
+* User pays `0.5 TGas` to send the `CreateAccount` action, costing `0.00005 NEAR`
+* User purchases `100 TGas` for `0.1 NEAR` and attaches it to the receipt (buying at the purchase price)
+* Executing the create account actions burns `7.2 TGas` at the burn price
+* The FunctionCall action burns `50 TGas` at the burn price
+* There's `42.8 TGas` of unused gas
+* The price surplus is equal to `57.2 TGas * (purchase_price - burn_price) = 0.05148 NEAR`
+* Normally we would refund the whole price surplus to cover for the price difference, but this receipt created a new account. This means that we will charge extra. The extra charge is `0.007 - 7.2 TGas * burn_price = 0.00628 NEAR`. This is subtracted from the price difference refund.
+* The price difference refund is equal to `0.05148 - 0.00628 = 0.0452 NEAR`
+* The unused gas refund is calculated normally: `42.8 * purchase_price = 0.0428 NEAR`
+* The final cost is `0.00005 + 0.1 - 0.0452 - 0.0428 = 0.01205 NEAR`
+
+The final cost is `0.00628 NEAR` higher than before the change. This is because we charge at least `0.007 NEAR` for creating the new account. The cost of burning gas inside of the function call remains unchanged.
+
+#### CreateAccount during congestion (high gas price)
+
+Now let's imagine what happens when `gas_price` is higher than `min_gas_purchase_price`. Let's say that `gas_price = 0.01 NEAR/TGas`.
+The transaction contains a single `CreateAccount` action.
+
+Previously:
+* `gas_price = 0.01 NEAR/TGas`
+* User pays `3.85 TGas` to send the `CreateAccount` action, costing `0.0385 NEAR`
+* User attaches `3.85 TGas` to the receipt to cover the execution cost of the `CreateAccount` action. This gas is purchased for `0.0385 NEAR`.
+* The receipt executes, not generating any refunds.
+* The final cost is `2 * 0.0385 = 0.077 NEAR`
+
+After the change:
+* `gas_price = 0.01 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
+* `purchase_price = 0.01 NEAR/TGas`
+* User pays `0.5 TGas` to send the `CreateAccount` action, costing `0.005 NEAR`
+* User attaches `7.2 TGas` to the receipt to cover the execution cost of the `CreateAccount` action. This gas is purchased for `0.072 NEAR` (using purchase price).
+* The gas is burned at the burn price, which is the same as the purchase price. There's no surplus.
+* Burning at this price costs `0.072 NEAR`, which is more than the desired cost (`0.007 NEAR`), so there is no need to charge extra.
+* The final cost is `0.005 + 0.072 = 0.077 NEAR`
+
+When the cost of the burned gas is higher than `0.007 NEAR`, we don't charge anything extra, the cost is high enough already.
+
+### NEP-536 (refund penalty) incompatibility
+
+NEP-536 introduced penalties for attaching more gas than needed. The unused gas refund would be reduced by 5% or 1TGas to discourage overattaching gas and reduce the number of refund receipts. The feature is currently disabled on mainnet (penalty set to zero).
+
+This NEP goes against this idea. Now gas is always purchased at a higher price, which means that most receipts generate a refund, even when the user attached the exact amount of gas needed for executing that transaction. This means that the penalty doesn't help to reduce the number of refund receipts. It still helps a bit with congestion control, which estimates the amount of work by looking at the attached gas.
+
+This is not ideal, but we couldn't find a better alternative to fix the problem.
+
+Overall I think attaching more gas than needed is pretty sound, often the user has no way to predict how much gas the transaction will burn.
+
+The refund code is preserved (5% or 1 TGas of unused gas, priced at the normal burn price), so it's still possible to enable the refund penalty in the future if needed.
+
+### Meta transactions
+
+Rebalancing the gas costs has a small impact on meta transactions. Meta transactions charge the `send` cost twice - first for the original `DelegateAction` and then a second time when sending the actual action receipt. This NEP reduces the `send` costs of some actions, which means that this double cost becomes lower as well. This is not an issue, but it's worth noting.
+
+### Gas key changes
+
+The recent gas keys NEP (NEP-611) added a new failure mode for transactions - when a gas key transaction fails because of insufficient balance to cover the deposit (`InvalidTxError::NotEnoughBalanceForDeposit`), all of the gas belonging to this transaction is burned. Both the gas burned on converting the transaction to a receipt, and the gas attached to the receipt.
+
+Now that the gas attached to the receipt is purchased at a price that's 10x as high, it would also mean that 10x as much NEAR is burned on deposit failure. This is undesirable, as the cost of other operations was supposed to remain unchanged.
+
+To simplify things we are going to change it so that only the gas burned on converting the transaction is forfeited. The gas that was attached to the receipt will be refunded. This makes the cost of failure a bit lower than before, but the logic is still sound - a failed gas key transaction burns the gas that was needed to process it. The attached gas doesn't matter there.
+
+## Reference Implementation
+
+The feature is implemented in nearcore behind the `AccountCostIncrease` protocol feature. The reference implementation is available in the following pull requests:
+
+* Gas key changes: https://github.com/near/nearcore/pull/15907
+* The main PR: https://github.com/near/nearcore-private/pull/227
+
+## Security Implications
+
+* **Remove storage underpricing** The change fixes storage pricing inconsistency improving security and sustainability of the protocol.
+* **Charge never exceeds available funds.** The amount actually charged for account creation is `min(amount_to_charge, available_surplus)`. Combined with the invariant `min_gas_purchase_price * create_account.execution_gas >= account_creation_charge`, any receipt whose gas was purchased at or above `min_gas_purchase_price` always has enough surplus to cover the full charge.
+* **Legacy receipts purchased before activation.** Receipts created before the feature was activated may have purchased their gas at a price below `min_gas_purchase_price`. For such a receipt the available surplus can be smaller than the desired charge; in that case only the available surplus is taken (the charge is capped), so the protocol never fails to apply a valid receipt. This is a transient effect that disappears once all in-flight receipts were created post-activation.
+
+## Alternatives
+
+* **Increase the gas cost of creating new accounts** We could try to increase the gas cost to 77 TGas. However this has many problems. It would be a huge breaking change, and the gas cost wouldn't really reflect the compute required to handle the operation, as it's meant to.
+* **Remove zero balance accounts** We could get rid of the notion of zero balance accounts. Then all storage would have to be paid for with storage deposits. Again a huge breaking change.
+* **Alternative means of paying for storage** There could be another way to pay for storage - e.g. "storage gas". We explored the idea, but it's complicated and not really backwards compatible.
+* **Raise minimum gas price 10x to 0.001 NEAR/TGAS** - we could raise the minimum gas price 10x. This would make everything 10x as expensive, including account creation. This would work, but it would make all operations more expensive, not just account creation, and we wanted to avoid that.
+
+Raising purchase gas price 10x and refunding for the difference between burn price and gas price seems like an optimal solution - it achieves the goal with minimum side effects and breaking changes.
+
+## Future possibilities
+
+* The same "fixed NEAR charge funded from a gas-price surplus" mechanism could be applied to other operations whose true cost to the network is poorly captured by gas pricing.
+* We could reduce the number of refund receipts by delaying all of the refunds until the last receipt in the promise chain. For simple receipts (without `FunctionCall` actions) we could also predict how much gas they will burn and create the refund earlier, improving latency. These optimizations would be nice to have, but they are not necessary for now.
+* This change goes against the spirit of refund penalties added in NEP-536. Currently refund penalities are disabled, so it doesn't matter, but we should revisit this problem in the future
+* The `account_creation_charge` and `min_gas_purchase_price` are runtime parameters and can be tuned via future protocol versions as the economics evolve.
+* Currently transfers to implicit accounts are pretty expensive because they might create an account. We could make them cheaper when the transfer doesn't create an account by refunding the proper amount.
+
+## Consequences
+
+### Positive
+
+* The storage cost of creating new accounts is now in line with the expected storage deposit cost. Storage cost model becomes more sound.
+
+### Neutral
+
+* Gas attached to a receipt is now purchased at `min_gas_purchase_price` and burned at the (possibly lower) current price, with the difference refunded. This decouples the purchase price from the burn price for all receipts.
+* Sending a meta transaction that creates an account charges a bit less for the send fees. Delegate actions charge double the send fee, and send fee became lower for some actions.
+
+### Negative
+
+* Creating accounts becomes more expensive, which could be a problem for some users.
+* Users must hold more NEAR upfront to submit any transaction because of the higher purchase price
+* There will be more refund receipts, which will increase the latency of some transactions by 1 block time.
+
+### Backwards Compatibility
+
+Inside the runtime the change is fully backwards compatible - all existing smart contracts will continue to work fine.
+
+The only breaking change is in the costs of running a transaction. The gas purchased at the start of the transaction will cost 10x more, so the minimum balance required to start a transaction becomes 10x higher. For example starting a transaction with 100 TGas currently costs `0.01 NEAR`. After the change, starting this transaction will cost `0.1 NEAR`. The final cost of the transaction remains the same thanks to refunds (as long as the transaction doesn't create a new account).
+
+When the transaction creates a new account its final cost becomes higher than before, charging `0.007 NEAR` per created account.
+
+Existing logic for submitting transactions might require adjusting to match the new transaction costs.
+
+## Changelog
+
+[The changelog section provides historical context for how the NEP developed over time. Initial NEP submission should start with version 1.0.0, and all subsequent NEP extensions must follow [Semantic Versioning](https://semver.org/). Every version should have the benefits and concerns raised during the review. The author does not need to fill out this section for the initial draft. Instead, the assigned reviewers (Subject Matter Experts) should create the first version during the first technical review. After the final public call, the author should then finalize the last version of the decision context.]
+
+### 1.0.0 - Initial Version
+
+> Placeholder for the context about when and who approved this NEP version.
+
+#### Benefits
+
+> List of benefits filled by the Subject Matter Experts while reviewing this version:
+
+* Benefit 1
+* Benefit 2
+
+#### Concerns
+
+> Template for Subject Matter Experts review for this version:
+> Status: New | Ongoing | Resolved
+
+|   # | Concern | Resolution | Status |
+| --: | :------ | :--------- | -----: |
+|   1 |         |            |        |
+|   2 |         |            |        |
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/neps/nep-0642.md
+++ b/neps/nep-0642.md
@@ -259,8 +259,8 @@ To simplify things we are going to change it so that only the gas burned on conv
 
 The feature is implemented in nearcore behind the `AccountCostIncrease` protocol feature. The reference implementation is available in the following pull requests:
 
-* Gas key changes: https://github.com/near/nearcore/pull/15907
-* The main PR: https://github.com/near/nearcore-private/pull/227
+* Gas key changes: https://github.com/near/nearcore/pull/15835
+* The main PR: https://github.com/near/nearcore/pull/15907
 
 ## Security Implications
 

--- a/neps/nep-0642.md
+++ b/neps/nep-0642.md
@@ -312,6 +312,18 @@ When the transaction creates a new account its final cost becomes higher than be
 
 Existing logic for submitting transactions might require adjusting to match the new transaction costs.
 
+### Contributors
+
+People who contributed to the design:
+
+* Andrea Spurio
+* Anton Astafiev
+* Arseny Mitin
+* Darioush Jalali
+* Jakob Meier
+* Matej Pavlovic
+* Waclaw Banasik
+
 ## Changelog
 
 [The changelog section provides historical context for how the NEP developed over time. Initial NEP submission should start with version 1.0.0, and all subsequent NEP extensions must follow [Semantic Versioning](https://semver.org/). Every version should have the benefits and concerns raised during the review. The author does not need to fill out this section for the initial draft. Instead, the assigned reviewers (Subject Matter Experts) should create the first version during the first technical review. After the final public call, the author should then finalize the last version of the decision context.]

--- a/neps/nep-0642.md
+++ b/neps/nep-0642.md
@@ -152,6 +152,7 @@ Here are a few examples to make things clearer. The numbers in these examples mi
 Let's imagine a simple transaction with a single FunctionCall action. The user attaches 100 TGas to the receipt, and the function call burns 50 TGas during execution.
 
 Previously:
+
 * `gas_price = 0.0001 NEAR/TGas`
 * User purchases `100 TGas` for `0.01 NEAR`
 * The receipt burns `50 TGas`
@@ -160,6 +161,7 @@ Previously:
 * The final cost is `0.005 NEAR`
 
 After the change:
+
 * `gas_price = 0.0001 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
 * `purchase_price = 0.001 NEAR/TGas`
 * User purchases `100 TGas` for `0.1 NEAR` (buying at the purchase price)
@@ -175,6 +177,7 @@ After the change:
 Now let's take a transaction which creates an account and runs a FunctionCall action (actions: `[CreateAccount, FunctionCall]`). The user attaches 100 TGas to the receipt, the function call burns 50 TGas during execution. We will omit the base transaction cost and the send costs of the `FunctionCall` action for simplicity, they're the same in both cases.
 
 Previously:
+
 * `gas_price = 0.0001 NEAR/TGas`
 * User pays `3.85 TGas` to send the `CreateAccount` action, costing `0.000385 NEAR`
 * User purchases `100 TGas` for `0.01 NEAR` and attaches it to the receipt
@@ -187,6 +190,7 @@ Previously:
 Notice that the final cost is `0.00077 NEAR` higher than the previous example, which means that creating an account costs `0.00077 NEAR`.
 
 After the change:
+
 * `gas_price = 0.0001 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
 * `purchase_price = 0.001 NEAR/TGas`
 * User pays `0.5 TGas` to send the `CreateAccount` action, costing `0.00005 NEAR`
@@ -208,6 +212,7 @@ Now let's imagine what happens when `gas_price` is higher than `min_gas_purchase
 The transaction contains a single `CreateAccount` action.
 
 Previously:
+
 * `gas_price = 0.01 NEAR/TGas`
 * User pays `3.85 TGas` to send the `CreateAccount` action, costing `0.0385 NEAR`
 * User attaches `3.85 TGas` to the receipt to cover the execution cost of the `CreateAccount` action. This gas is purchased for `0.0385 NEAR`.
@@ -215,6 +220,7 @@ Previously:
 * The final cost is `2 * 0.0385 = 0.077 NEAR`
 
 After the change:
+
 * `gas_price = 0.01 NEAR/TGas`, `min_gas_purchase_price = 0.001 NEAR/TGas`
 * `purchase_price = 0.01 NEAR/TGas`
 * User pays `0.5 TGas` to send the `CreateAccount` action, costing `0.005 NEAR`

--- a/neps/nep-0642.md
+++ b/neps/nep-0642.md
@@ -255,6 +255,16 @@ Now that the gas attached to the receipt is purchased at a price that's 10x as h
 
 To simplify things we are going to change it so that only the gas burned on converting the transaction is forfeited. The gas that was attached to the receipt will be refunded. This makes the cost of failure a bit lower than before, but the logic is still sound - a failed gas key transaction burns the gas that was needed to process it. The attached gas doesn't matter there.
 
+### Actions that don't create an account
+
+There are some actions which might look like they would create an account, but they don't:
+
+* Gas refund to a non-existent implicit account
+* DeleteAccount where the beneficiary of the funds is a non-existent implicit account
+* DelegateAction where the sender of the inner actions is a non-existent implicit account
+
+These actions do not create an account, so they don't need to be covered by this NEP.
+
 ## Reference Implementation
 
 The feature is implemented in nearcore behind the `AccountCostIncrease` protocol feature. The reference implementation is available in the following pull requests:


### PR DESCRIPTION
This proposal makes creating a new account on NEAR roughly 10x more expensive than it is today. The cost of other operations remains unchanged.

This is needed to bring the cost of storage taken up by the account in line with the cost of storage paid for with storage deposits. Currently the storage taken up by new accounts is cheaper than storage purchased with storage deposits, which makes for an unfair balance.

The cost increase will be achieved by increasing the upfront gas purchase price 10x. For creating an account we will charge the full 10x gas price. For other operations we will charge a lower price and refund the difference, so that the final cost remains unchanged.