### PR TITLE
ci: ignore eprint.iacr.org in markdown-link-check

### DIFF
--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^https://www.w3.org/"
+    },
+    {
+      "pattern": "^https://eprint.iacr.org"
     }
   ],
   "timeout": "20s",

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -19,7 +19,7 @@
       "pattern": "^https://www.w3.org/"
     },
     {
-      "pattern": "^https://eprint.iacr.org"
+      "pattern": "^https://eprint\\.iacr\\.org/"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
The Lint job's `markdown-link-check` scans every markdown file and fails on the eprint.iacr.org PDF in `neps/nep-0488.md`, which sits behind a Cloudflare bot challenge (`cf-mitigated: challenge` → 403) even though the paper resolves fine in a browser. This adds `^https://eprint\.iacr\.org/` to `ignorePatterns` in `.mlc_config.json`, alongside the other bot-blocking hosts already listed.