### PR TITLE
NEP-646: FIPS 202 SHA-3 Host Functions

### DIFF
--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -133,7 +133,7 @@ Before the flags are active, the import names do not resolve and a contract that
 ## Reference Implementation
 
 - `sha3_256` is fully implemented and merged: [nearcore#16006] (commit `b9a8d559e`), including the host function in `runtime/near-vm-runner/src/logic/logic.rs`, the gated import, the `ExtCosts`/`Parameter` wiring, the nightly config diff (`core/parameters/res/runtime_configs/156.yaml`), and an end-to-end test (`test-loop-tests/src/tests/sha3_256.rs`).
-- `sha3_384` and `sha3_512` are mechanical mirrors of that commit — the same ~20-line host-function body with the digest type swapped, the same import/parameter plumbing, and the same test shape with the KAT values from this NEP. The `sha3` crate (RustCrypto) already provides `Sha3_384`/`Sha3_512` and has been a consensus dependency since genesis via `keccak256`/`keccak512`. A draft nearcore PR implementing the two remaining functions is forthcoming and will be linked here before this NEP enters SME review.
+- `sha3_384` and `sha3_512` are implemented in [nearcore#16029] as mechanical mirrors of that commit — the same ~20-line host-function body with the digest type swapped, the same import/parameter plumbing, and the same test shape with the KAT values from this NEP, gated by `sha3_384_512_host_fns` at nightly protocol version 157. The `sha3` crate (RustCrypto) already provides `Sha3_384`/`Sha3_512` and has been a consensus dependency since genesis via `keccak256`/`keccak512`.
 
 ## Security Implications
 
@@ -254,5 +254,6 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [EIP-8200]: https://eips.ethereum.org/EIPS/eip-8200
 [nearcore#4285]: https://github.com/near/nearcore/issues/4285
 [nearcore#16006]: https://github.com/near/nearcore/pull/16006
+[nearcore#16029]: https://github.com/near/nearcore/pull/16029
 [near/mpc]: https://github.com/near/mpc
 [near-sdk-rs#1571]: https://github.com/near/near-sdk-rs/pull/1571

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -122,7 +122,7 @@ Two new `ExtCosts` pairs (`sha3_384_base`/`_byte`, `sha3_512_base`/`_byte`) take
 
 ### Protocol gating
 
-`sha3_256` is already gated by the `sha3_256_host_fn` runtime-config flag, enabled at nightly protocol version 156. The two new functions are gated by a single additional flag (the reference implementation uses `sha3_384_512_host_fns`, following the multi-function-flag precedent of `yield_with_id_host_fns`). Stabilization SHOULD flip both flags at the same protocol version so the family becomes available atomically.
+All three functions are gated by a single runtime-config flag, `sha3_host_fns`, enabled at nightly protocol version 156. (The flag was originally introduced as `sha3_256_host_fn` gating only `sha3_256`; it was renamed and extended to cover the whole family during review of the reference implementation, following the multi-function-flag precedent of `yield_with_id_host_fns` and `gas_key_host_fns`.) A single flag means stabilization necessarily activates the family atomically.
 
 Before the flags are active, the import names do not resolve and a contract that imports them fails to instantiate — the same behavior as every previous host-function addition (`p256_verify`, `chain_id`, the yield functions). No pre-activation behavior changes.
 
@@ -133,7 +133,7 @@ Before the flags are active, the import names do not resolve and a contract that
 ## Reference Implementation
 
 - `sha3_256` is fully implemented and merged: [nearcore#16006] (commit `b9a8d559e`), including the host function in `runtime/near-vm-runner/src/logic/logic.rs`, the gated import, the `ExtCosts`/`Parameter` wiring, the nightly config diff (`core/parameters/res/runtime_configs/156.yaml`), and an end-to-end test (`test-loop-tests/src/tests/sha3_256.rs`).
-- `sha3_384` and `sha3_512` are implemented in [nearcore#16029] as mechanical mirrors of that commit — the same ~20-line host-function body with the digest type swapped, the same import/parameter plumbing, and the same test shape with the KAT values from this NEP, gated by `sha3_384_512_host_fns` at nightly protocol version 157. The `sha3` crate (RustCrypto) already provides `Sha3_384`/`Sha3_512` and has been a consensus dependency since genesis via `keccak256`/`keccak512`.
+- `sha3_384` and `sha3_512` are implemented in [nearcore#16029] as mechanical mirrors of that commit — the same ~20-line host-function body with the digest type swapped, the same import/parameter plumbing, and the same test shape with the KAT values from this NEP, gated by the shared `sha3_host_fns` flag at nightly protocol version 156. The `sha3` crate (RustCrypto) already provides `Sha3_384`/`Sha3_512` and has been a consensus dependency since genesis via `keccak256`/`keccak512`.
 
 ## Security Implications
 

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -1,0 +1,258 @@
+---
+NEP: 646
+Title: FIPS 202 SHA-3 Host Functions
+Authors: Ricky (@r-near), Vladyslav Savchyn (@vsavchyn-dev)
+Status: Draft
+DiscussionsTo: https://github.com/near/NEPs/pull/646
+Type: Protocol
+Version: 1.0.0
+Created: 2026-07-06
+LastUpdated: 2026-07-06
+---
+
+## Summary
+
+This proposal adds the fixed-output [FIPS 202] SHA-3 hash family to the NEAR VM as host functions: **`sha3_256`**, **`sha3_384`**, and **`sha3_512`**. They mirror the existing `keccak256` / `keccak512` host functions in signature, register semantics, and gas model.
+
+NEAR's VM has exposed the *legacy* Keccak variants since genesis, but legacy Keccak and standardized SHA-3 use different domain-separation padding and produce unrelated digests for every input. Contracts therefore cannot compute a FIPS-202 digest on-chain today except by embedding a pure-Wasm implementation, which costs roughly an order of magnitude more gas than a host function and adds per-contract code and audit surface.
+
+Concrete on-chain consumers of SHA3-256 now exist in the protocol itself: the ML-DSA-65 access-key handle introduced by [NEP-645] is a domain-separated SHA3-256 digest, Universal Account IDs (UAID) are derived with SHA3-256, and the MPC service derives tweaks and app ids with SHA3-256 inside a contract. A `sha3_256` host function has accordingly already been merged into nearcore behind a nightly protocol feature ([nearcore#16006]). This NEP specifies that function, completes the fixed-output family with `sha3_384` and `sha3_512`, and proposes stabilizing the three together, so that the padding, cost, and test-vector details of the whole family are reviewed once.
+
+The SHAKE extendable-output functions (XOFs) from the same standard are explicitly out of scope; see [Future possibilities](#future-possibilities).
+
+## Motivation
+
+### Contracts need standardized SHA-3, and legacy Keccak cannot substitute
+
+FIPS 202 defines the SHA-3 functions as Keccak with a two-bit domain-separation suffix appended to the message before padding. The `keccak256`/`keccak512` host functions NEAR has had since genesis implement the *pre-standardization* variant without the suffix (the Ethereum flavor). The two families share the permutation but disagree on every digest:
+
+| Input | Keccak-256 (existing host fn) | SHA3-256 (FIPS 202) |
+| --- | --- | --- |
+| `""` | `c5d2460186f7233c…` | `a7ffc6f8bf1ed766…` |
+
+Any protocol, standard, or external system specified against FIPS 202 is therefore unreachable from the existing host functions. This is not hypothetical: a FIPS-202 `sha3_256` host function was first requested in 2021 for verifying ICON-chain Merkle proofs ([nearcore#4285]) and closed without action; five years later the protocol itself needed exactly that function.
+
+### Present consumers of SHA3-256
+
+- **ML-DSA-65 access-key handles ([NEP-645]).** Post-quantum access keys are stored on-trie as `SHA3-256(b"near:ml-dsa-65-pubkey-hash:v1" || raw_public_key)`. A contract or wallet contract that wants to match an on-chain access-key entry against a known 1952-byte public key must compute this digest. As a host function this costs about 47.8 Ggas (~0.048 Tgas); in pure Wasm it costs roughly an order of magnitude more.
+- **Universal Account IDs.** UAID derives an account id as `0u` plus a base32 encoding of a SHA3-256 digest of the account's state-init ([nearcore#16006]). Contracts that create or validate such accounts need the same digest.
+- **MPC key derivation.** The MPC service derives per-user tweaks and app ids as domain-separated SHA3-256 digests (`derive_tweak`, `derive_app_id` in [near/mpc]), and these derivations run inside the MPC smart contract today using a pure-Wasm SHA-3 implementation.
+
+Ecosystem plumbing already anticipates the host functions: the `near-digest` crate ([near-sdk-rs#1571], ported from `near/intents`' `defuse-digest`) selects hash backends at compile time — host function on-chain, RustCrypto elsewhere — so existing contract code switches to the host-function path with a dependency bump and no code changes.
+
+### Why the whole fixed-output family rather than SHA3-256 alone
+
+Demand today is concentrated on SHA3-256, and this NEP is explicit about that (see [Alternatives](#sha3-256-only)). The case for completing the family in the same protocol change is about the cost structure of host functions, not about present call sites:
+
+- **The marginal cost is near zero; the retrofit cost is a full protocol cycle.** Each additional variant is the same ~20-line implementation with a different digest type from a crate that has been a consensus dependency since genesis, and its gas cost is inherited from the already-measured `keccak512` (same permutation, same-or-better rate; see [Gas costs](#gas-costs-and-parameters)). Adding a variant later requires a new NEP, SME review, protocol version, release, and voting cycle — months of latency for whoever needs it, as the five-year gap between [nearcore#4285] and [nearcore#16006] demonstrates.
+- **The wider variants are standardized, not speculative, primitives.** [FIPS 186-5] approves the SHA-3 family, including SHA3-384 and SHA3-512, for ECDSA, RSA, and EdDSA signatures, with assigned object identifiers (e.g. `ecdsa-with-sha3-512`, OID 2.16.840.1.101.3.4.3.12) and CMS integration ([RFC 9688]). ML-KEM ([FIPS 203]), NIST's standardized post-quantum KEM, uses SHA3-512 as its internal function G in key generation, encapsulation, and the decapsulation re-encryption check, and SHA3-256 as H. Deployment of SHA3-384/512-based signatures is thin today, but a chain positioning itself as a verification platform for post-quantum cryptography should be able to compute the hash family those standards are written against.
+- **Digest-length demand is real in NEAR's own design history.** NEP-645 records that a 384-bit digest "would more conservatively match the keypair's quantum security margin" for the ML-DSA-65 handle and was rejected *only* because 48 bytes does not fit in a NEAR account id. Contract-level commitments (registries, attestations, long-lived anchors) have no account-id length constraint, so the same security reasoning that the protocol team itself applied leads such contracts to wider digests.
+- **Family-coherence review is cheaper done once.** The subtle parts of SHA-3 — the padding suffix, the rate/capacity split per variant, distinguishing the fixed-output functions from the XOFs — are shared across the family. Reviewing them once, with known-answer tests for all variants, is less total SME effort than three single-function reviews and eliminates the risk of a later variant shipping with an inconsistent detail.
+
+This NEP does **not** propose "add host functions whenever they are cheap" as a general rule. The scoping principle is narrower: when one member of a small, fixed, NIST-standardized family has independent justification, complete the family in the same change. An open-ended set (e.g. every hash NIST has ever approved) would not qualify.
+
+## Specification
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### Host functions
+
+Three host functions are added to the VM's `env` import namespace, with signatures identical to the existing `sha256` / `keccak256` / `keccak512`:
+
+```rust
+sha3_256(value_len: u64, value_ptr: u64, register_id: u64) -> ()
+sha3_384(value_len: u64, value_ptr: u64, register_id: u64) -> ()
+sha3_512(value_len: u64, value_ptr: u64, register_id: u64) -> ()
+```
+
+Each function:
+
+1. Reads `value_len` bytes of guest memory starting at `value_ptr` (or, per the existing register convention, reads the register whose id is `value_ptr` when `value_len == u64::MAX`).
+2. Computes the FIPS 202 digest of those bytes: SHA3-256, SHA3-384, or SHA3-512 respectively.
+3. Writes the digest — **32**, **48**, or **64** bytes respectively — into the register `register_id`.
+
+Errors are identical to the existing hash host functions: an out-of-bounds memory range or exceeding the register memory limit fails with `MemoryAccessViolation`, and running out of gas fails the usual way. The functions have no other failure modes; they are total, deterministic functions of their input bytes.
+
+The digests MUST be the FIPS 202 fixed-output functions, i.e. Keccak[c = 2·d] applied to the message with the two-bit domain-separation suffix `01` appended before `pad10*1` padding (the `0x06` byte in the customary LSB-first encoding). The legacy Keccak variants (suffix-free, `0x01` padding byte) and the SHAKE XOFs (suffix `1111`, `0x1F` byte) are different functions and MUST NOT be substituted.
+
+### Known-answer tests
+
+Implementations MUST reproduce the following digests (computed with the same `sha3` crate the reference implementation uses for `keccak256`/`keccak512`; they match the NIST FIPS 202 examples). The Keccak rows are included to make the domain separation from the existing host functions explicit:
+
+| Function | `""` (empty input) | `"abc"` |
+| --- | --- | --- |
+| `sha3_256` | `a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a` | `3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532` |
+| `sha3_384` | `0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004` | `ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25` |
+| `sha3_512` | `a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26` | `b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0` |
+| `keccak256` (existing) | `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` | `4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45` |
+| `keccak512` (existing) | `0eab42de4c3ceb9235fc91acffe746b29c29a8c366b7c60e4e67c466f36a4304c00fa9caf9d87976ba469bcbe06713b435f091ef2769fb160cdab33d3670680e` | `18587dc2ea106b9a1563e32b3312421ca164c7f1f07bc922a9c83d77cea3a1e5d0c69910739025372dc14ac9642629379540c17e2a65b19d77aa511a9d00bb96` |
+
+### Gas costs and parameters
+
+The gas model is the standard `base + byte × input_len` used by every hash host function, charged in addition to the generic host-call base cost and the register-write costs:
+
+```
+base_host_cost
++ sha3_N_base + sha3_N_byte × value_len
++ write_register_base + write_register_byte × digest_len
+```
+
+All five Keccak-family functions run the same keccak-f[1600] permutation; they differ only in **rate** — how many input bytes each permutation call absorbs — and in output length:
+
+| Function | Rate (bytes absorbed per permutation) | Digest length |
+| --- | --- | --- |
+| `keccak256` / `sha3_256` | 136 | 32 |
+| `sha3_384` | 104 | 48 |
+| `keccak512` / `sha3_512` | 72 | 64 |
+
+The proposed parameter values reuse the existing, estimator-measured Keccak costs of the matching (or strictly slower) rate, following the precedent set when `sha3_256` was merged ("SHA3-256 shares the keccak-f permutation, so it reuses the keccak256 costs", [nearcore#16006]):
+
+| Parameter | Value | Source |
+| --- | --- | --- |
+| `wasm_sha3_256_base` | `5_879_491_275` | = `wasm_keccak256_base` (identical rate) — already merged |
+| `wasm_sha3_256_byte` | `21_471_105` | = `wasm_keccak256_byte` — already merged |
+| `wasm_sha3_384_base` | `5_811_388_236` | = `wasm_keccak512_base` (conservative: rate 104 vs 72) |
+| `wasm_sha3_384_byte` | `36_649_701` | = `wasm_keccak512_byte` (conservative) |
+| `wasm_sha3_512_base` | `5_811_388_236` | = `wasm_keccak512_base` (identical rate) |
+| `wasm_sha3_512_byte` | `36_649_701` | = `wasm_keccak512_byte` (identical rate) |
+
+`sha3_512` and `keccak512` do byte-for-byte identical work modulo the padding suffix, so inheriting the cost is exact. `sha3_384` absorbs 104 bytes per permutation where `keccak512` absorbs 72, so the inherited per-byte cost strictly *over*-charges it; this is deliberate (underpricing is the dangerous direction; see [Security Implications](#security-implications)). Re-running the runtime-parameter estimator for the two new functions before stabilization MAY replace these inherited values with measured ones, but is not required for safety.
+
+Two new `ExtCosts` pairs (`sha3_384_base`/`_byte`, `sha3_512_base`/`_byte`) take the next free discriminants in the append-only `ExtCosts` enum, alongside the already-assigned `sha3_256_base = 88` / `sha3_256_byte = 89`.
+
+### Protocol gating
+
+`sha3_256` is already gated by the `sha3_256_host_fn` runtime-config flag, enabled at nightly protocol version 156. The two new functions are gated by a single additional flag (the reference implementation uses `sha3_384_512_host_fns`, following the multi-function-flag precedent of `yield_with_id_host_fns`). Stabilization SHOULD flip both flags at the same protocol version so the family becomes available atomically.
+
+Before the flags are active, the import names do not resolve and a contract that imports them fails to instantiate — the same behavior as every previous host-function addition (`p256_verify`, `chain_id`, the yield functions). No pre-activation behavior changes.
+
+### SDK exposure
+
+`near-sys` and `near-sdk` gain the three functions alongside the existing hash functions (`env::sha3_256` etc. returning fixed-size arrays), and `near-digest` ([near-sdk-rs#1571]) wires its existing `Sha3_256` / `Sha3_512` types (plus a new `Sha3_384`) to the host-function backend under `cfg(near)`, replacing their current pure-Wasm-everywhere fallback. Contracts already using `near-digest` or `defuse-digest` then pick up the host functions through a dependency bump with no code changes.
+
+## Reference Implementation
+
+- `sha3_256` is fully implemented and merged: [nearcore#16006] (commit `b9a8d559e`), including the host function in `runtime/near-vm-runner/src/logic/logic.rs`, the gated import, the `ExtCosts`/`Parameter` wiring, the nightly config diff (`core/parameters/res/runtime_configs/156.yaml`), and an end-to-end test (`test-loop-tests/src/tests/sha3_256.rs`).
+- `sha3_384` and `sha3_512` are mechanical mirrors of that commit — the same ~20-line host-function body with the digest type swapped, the same import/parameter plumbing, and the same test shape with the KAT values from this NEP. The `sha3` crate (RustCrypto) already provides `Sha3_384`/`Sha3_512` and has been a consensus dependency since genesis via `keccak256`/`keccak512`. A draft nearcore PR implementing the two remaining functions is forthcoming and will be linked here before this NEP enters SME review.
+
+## Security Implications
+
+### No new cryptographic or consensus surface
+
+The functions are pure, deterministic, total functions of their input bytes, implemented by a crate that has been consensus-critical since genesis. There is no key material, no verification logic, no malleability question, and no input-dependent control flow relevant to consensus. The permutation count is a fixed function of input length, so execution time is input-length-dependent only — exactly the property the `base + byte × len` gas model prices.
+
+### Gas mispricing
+
+The main protocol risk of any host function is underpricing (an attacker buys more CPU time than the gas model assumes). The proposed costs are inherited from estimator-measured functions doing identical (`sha3_512`) or strictly more (`sha3_384`, per byte) permutation work, so they cannot undercharge relative to the already-accepted Keccak pricing. The safety margin built into the existing costs (the estimator's `SAFETY_MULTIPLIER`) carries over.
+
+### Wrong-variant misuse
+
+The most likely developer error is confusing legacy Keccak, fixed-output SHA-3, and SHAKE, which produce unrelated digests. This NEP mitigates by specification: the KAT table above makes the domain separation explicit and testable, host-function names follow the `sha3_` / `keccak` naming split already used by every major library, and SDK documentation MUST state that `keccak256` ≠ `sha3_256`.
+
+### Permanence
+
+Host functions are protocol surface forever: once a contract on any network calls `sha3_384` or `sha3_512`, the functions and their gas semantics are part of that chain's replay history and cannot be removed. This is the real cost of the proposal and is discussed honestly in [Consequences](#consequences). Two mitigating facts: NEAR has a single production client, so the multi-client consensus-divergence risk that drives precompile-aversion elsewhere (e.g. Ethereum's [EIP-8200] motivation cites zkEVM proving burden and cross-client maintenance) does not currently apply; and the closest precedent — `keccak512`, live since genesis with near-zero observed usage — has imposed no measurable maintenance or security cost in six years.
+
+## Alternatives
+
+### SHA3-256 only
+
+The status-quo direction: stabilize the merged `sha3_256` and defer 384/512 until a concrete consumer appears. This is the alternative with real weight, and the honest statement of the demand picture is: **no NEAR contract or protocol component consumes SHA3-384 or SHA3-512 on-chain today.** The wider variants exist in the ecosystem only as not-yet-wired types in `defuse-digest`/`near-digest`, and the one SHA3-384 use in the org (TEE attestation report data in [near/mpc]) is off-chain.
+
+It is rejected on the cost-structure grounds argued in [Motivation](#why-the-whole-fixed-output-family-rather-than-sha3-256-alone): the marginal cost of completing the family now is a few dozen lines and one shared SME review, while the cost of retrofitting a variant later is a full NEP-and-protocol cycle at months of latency — a trade the 2021→2026 history of `sha3_256` itself ([nearcore#4285] → [nearcore#16006]) prices concretely. Reviewers who weigh present demand more heavily than option value should prefer this alternative; the authors weigh the asymmetry the other way.
+
+### Keep computing SHA-3 in pure Wasm
+
+Contracts can (and today do) embed the `sha3` crate. This works and stays available; the host functions are an optimization, not an enabler. It is rejected as the *terminal* state because the gas cost is roughly an order of magnitude higher — material for high-volume contracts hashing kilobyte-scale inputs (ML-DSA-65 public keys are 1952 bytes; state-inits are comparable) — and because every contract embedding its own hash implementation adds code size and audit surface.
+
+### Treat `keccak512` as "close enough" to SHA3-512
+
+Rejected: the padding domains differ, so every digest differs, and no FIPS-202-specified system will interoperate with legacy-Keccak digests. This confusion is precisely what the KAT table exists to prevent.
+
+### Add SHAKE128/SHAKE256 in this NEP
+
+The XOFs from FIPS 202 are the primitives that post-quantum algorithms use *internally* (ML-DSA is specified entirely over SHAKE128/256; ML-KEM needs SHAKE in addition to SHA3-256/512), so an argument exists that they are the more future-relevant additions. They are deliberately out of scope: an XOF host function has a genuinely different API (an output-length parameter, plus a squeeze semantics decision), no major chain has shipped one to copy, and bundling that design question here would delay the straightforward fixed-output family. See [Future possibilities](#future-possibilities). Note the converse is also true and is not claimed by this NEP: the fixed-output family alone does not make any post-quantum algorithm implementable on-chain.
+
+### An `ml_dsa_65_verify` host function instead
+
+For the specific goal of verifying post-quantum signatures in contracts, a whole-verification host function (the pattern of Ethereum's draft [EIP-8051]) is the right tool, and NEP-645 already lists it as a future possibility. It is complementary, not competing: it serves signature verification, while this NEP serves hash interoperability (key handles, account derivation, KDFs, external-chain digests) that a verify function does not address.
+
+## Future possibilities
+
+- **SHAKE128 / SHAKE256 XOF host functions.** A follow-up could add `shake128(value_len, value_ptr, out_len, register_id)`-shaped functions. These are the internals of ML-DSA ([FIPS 204]) and ML-KEM ([FIPS 203]), so they become relevant if contracts are ever meant to implement post-quantum constructions directly. The gas model needs an `out_len`-dependent term (squeezing runs the permutation once per 168/136 output bytes).
+- **`ml_dsa_65_verify`.** Tracked in NEP-645's future possibilities; would serve wallet contracts, bridges, and DEXs.
+- **Derived SHA-3 constructions** (cSHAKE, KMAC, TupleHash from [NIST SP 800-185]) only become candidates if the XOFs land and demand exists; they are compositions a contract can also build itself.
+- **SHA2-512.** Occasionally requested for Ed25519-adjacent tooling; explicitly not included here (different standard, different family, no present consumer) and would need its own justification.
+
+## Consequences
+
+### Positive
+
+- Contracts can compute standardized SHA-3 digests at host-function cost: ML-DSA-65 key-handle recomputation (~47.8 Ggas for a 1952-byte key), UAID derivation, and MPC tweak/app-id derivation get roughly an order of magnitude cheaper, and FIPS-202 interoperability with external systems becomes practical.
+- The whole fixed-output family is specified, priced, and test-vectored in one review; no future single-variant NEP cycles for fixed-output SHA-3.
+- Contracts using `near-digest`/`defuse-digest` adopt the host functions via a dependency bump with no code changes.
+- Purely additive: no existing behavior, key, or contract is affected.
+
+### Neutral
+
+- `sha3_384` and `sha3_512` may see little immediate use. The authors consider this acceptable given the near-zero marginal and carrying cost (see `keccak512`, live since genesis with the same profile and no observed burden), but it is a fair point of review and the reason the scoping principle in [Motivation](#why-the-whole-fixed-output-family-rather-than-sha3-256-alone) is stated as narrowly as it is.
+- `sha3_256` is already merged at nightly protocol version 156; this NEP partly standardizes existing implementation rather than proposing from scratch. The authors consider working reference code an asset for review, but note the sequencing.
+
+### Negative
+
+- Six new gas parameters, four new `ExtCosts` discriminants, two runtime-config flags, and three import names become permanent protocol surface.
+- If the family-completion argument is applied carelessly in the future, it could erode the "named consumer" bar that has historically gated host functions (NEP-364's light-client benchmarks, NEP-488's BLS use cases, NEP-635's passkeys). The scoping principle in this NEP — complete a small standardized family only when a member is independently justified — is written to be citable *against* such erosion.
+
+### Backwards Compatibility
+
+Fully backwards compatible. The functions are additive and feature-gated; before activation the imports do not resolve, which is the established behavior for every host-function addition. No state migration, no change to any existing function's semantics or pricing, no SDK breaking change (new functions and backends only). Contracts compiled against older SDKs are unaffected.
+
+## Unresolved Issues
+
+- **Stabilization target.** Whether the family stabilizes at the next mainline protocol version after 2.13's (86 or later) is a release-planning question outside this NEP; the NEP only requires the three functions activate together.
+- **Inherited vs measured costs.** Whether to re-run the parameter estimator for `sha3_384`/`sha3_512` before stabilization or keep the (safe, conservative) inherited keccak512 values.
+- **SHAKE scope.** Whether the SHAKE XOFs should be folded into this NEP after all, or kept as the separate follow-up the authors prefer. SME input is explicitly invited here.
+- **SDK surface.** Final naming and shape of the `near-sdk` env functions and the `near-digest` backend wiring (tracked in [near-sdk-rs#1571]).
+
+## Changelog
+
+### 1.0.0 - Initial Version
+
+> Placeholder for the context about when and who approved this NEP version.
+
+#### Benefits
+
+> List of benefits filled by the Subject Matter Experts while reviewing this version:
+
+- Benefit 1
+- Benefit 2
+
+#### Concerns
+
+> Template for Subject Matter Experts review for this version:
+> Status: New | Ongoing | Resolved
+
+|   # | Concern | Resolution | Status |
+| --: | :------ | :--------- | -----: |
+|   1 |         |            |        |
+|   2 |         |            |        |
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+<!-- links -->
+
+[FIPS 202]: https://csrc.nist.gov/pubs/fips/202/final
+[FIPS 203]: https://csrc.nist.gov/pubs/fips/203/final
+[FIPS 204]: https://csrc.nist.gov/pubs/fips/204/final
+[FIPS 186-5]: https://csrc.nist.gov/pubs/fips/186-5/final
+[RFC 9688]: https://www.rfc-editor.org/rfc/rfc9688.html
+[NIST SP 800-185]: https://csrc.nist.gov/pubs/sp/800/185/final
+[NEP-645]: https://github.com/near/NEPs/pull/645
+[EIP-8051]: https://eips.ethereum.org/EIPS/eip-8051
+[EIP-8200]: https://eips.ethereum.org/EIPS/eip-8200
+[nearcore#4285]: https://github.com/near/nearcore/issues/4285
+[nearcore#16006]: https://github.com/near/nearcore/pull/16006
+[near/mpc]: https://github.com/near/mpc
+[near-sdk-rs#1571]: https://github.com/near/near-sdk-rs/pull/1571

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -71,7 +71,7 @@ Each function:
 2. Computes the FIPS 202 digest of those bytes: SHA3-256, SHA3-384, or SHA3-512 respectively.
 3. Writes the digest — **32**, **48**, or **64** bytes respectively — into the register `register_id`.
 
-Errors are identical to the existing hash host functions: an out-of-bounds memory range or exceeding the register memory limit fails with `MemoryAccessViolation`, and running out of gas fails the usual way. The functions have no other failure modes; they are total, deterministic functions of their input bytes.
+Errors are identical to the existing hash host functions: an out-of-bounds memory range or exceeding the register memory limit fails with `MemoryAccessViolation`, a register-backed call (`value_len == u64::MAX`) that names an unset register id fails with `InvalidRegisterId`, and running out of gas fails the usual way. Once the input bytes are read, the functions have no other failure modes; the digest is a total, deterministic function of those bytes.
 
 The digests MUST be the FIPS 202 fixed-output functions, i.e. Keccak[c = 2·d] applied to the message with the two-bit domain-separation suffix `01` appended before `pad10*1` padding (the `0x06` byte in the customary LSB-first encoding). The legacy Keccak variants (suffix-free, `0x01` padding byte) and the SHAKE XOFs (suffix `1111`, `0x1F` byte) are different functions and MUST NOT be substituted.
 

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -200,7 +200,7 @@ For the specific goal of verifying post-quantum signatures in contracts, a whole
 
 ### Negative
 
-- Six new gas parameters, four new `ExtCosts` discriminants, two runtime-config flags, and three import names become permanent protocol surface.
+- Six new gas parameters, four new `ExtCosts` discriminants, one runtime-config flag, and three import names become permanent protocol surface.
 - If the family-completion argument is applied carelessly in the future, it could erode the "named consumer" bar that has historically gated host functions (NEP-364's light-client benchmarks, NEP-488's BLS use cases, NEP-635's passkeys). The scoping principle in this NEP — complete a small standardized family only when a member is independently justified — is written to be citable *against* such erosion.
 
 ### Backwards Compatibility

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -122,7 +122,7 @@ Two new `ExtCosts` pairs (`sha3_384_base`/`_byte`, `sha3_512_base`/`_byte`) take
 
 ### Protocol gating
 
-All three functions are gated by a single runtime-config flag, `sha3_host_fns`, enabled at nightly protocol version 156. (The flag was originally introduced as `sha3_256_host_fn` gating only `sha3_256`; it was renamed and extended to cover the whole family during review of the reference implementation, following the multi-function-flag precedent of `yield_with_id_host_fns` and `gas_key_host_fns`.) A single flag means stabilization necessarily activates the family atomically.
+All three functions are gated by a single runtime-config flag, `sha3_host_fns`, enabled at nightly protocol version 156. Nightly protocol versions are pre-release versions compiled only into nearcore's nightly builds through runtime-config diffs (the YAML files under `core/parameters/res/runtime_configs/`, here `156.yaml`); they are not part of any stable protocol release until stabilized. (The flag was originally introduced as `sha3_256_host_fn` gating only `sha3_256`; it was renamed and extended to cover the whole family during review of the reference implementation, following the multi-function-flag precedent of `yield_with_id_host_fns` and `gas_key_host_fns`.) A single flag means stabilization necessarily activates the family atomically.
 
 Before the flags are active, the import names do not resolve and a contract that imports them fails to instantiate — the same behavior as every previous host-function addition (`p256_verify`, `chain_id`, the yield functions). No pre-activation behavior changes.
 

--- a/neps/nep-0646.md
+++ b/neps/nep-0646.md
@@ -93,9 +93,11 @@ The gas model is the standard `base + byte × input_len` used by every hash host
 
 ```
 base_host_cost
-+ sha3_N_base + sha3_N_byte × value_len
++ sha3_N_base + sha3_N_byte × input_len
 + write_register_base + write_register_byte × digest_len
 ```
+
+Here `input_len` is the number of bytes actually hashed — the length of the memory range read, or, for a register-backed call (`value_len == u64::MAX`), the length of the register's contents — not the literal `value_len` argument. This matches the existing hash host functions, which charge the per-byte cost against the bytes actually read.
 
 All five Keccak-family functions run the same keccak-f[1600] permutation; they differ only in **rate** — how many input bytes each permutation call absorbs — and in output length:
 


### PR DESCRIPTION
Adds NEP-646: `sha3_256`, `sha3_384`, and `sha3_512` host functions (fixed-output FIPS 202 family).

`sha3_256` is already merged in nearcore behind a nightly flag (near/nearcore#16006); this NEP specifies it and completes the family. See the NEP text for motivation, gas parameters, and known-answer tests.