### PR TITLE
NEP-635: document signature malleability (high-s accepted)

### DIFF
--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -112,7 +112,7 @@ This is a deliberate choice. WebAuthn does not require low-s, and widely deploye
 
 Malleability is only a concern for applications that derive uniqueness or replay protection from the signature bytes themselves (for example, using a hash of the signature as a nullifier). Such applications MUST take one of the following measures:
 
-- Enforce low-s in the contract. With the raw `r || s` encoding, `s` occupies bytes 32..64 of the signature (big-endian), so the check is a byte comparison of that value against ⌊n/2⌋ = `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8`, rejecting signatures whose `s` exceeds it.
+- Enforce low-s in the contract. With the raw `r || s` encoding, `s` is the last 32 bytes of the 64-byte signature (offset 32, length 32), interpreted as a big-endian integer, so the check is a byte comparison of that value against ⌊n/2⌋ = `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8`, rejecting signatures whose `s` exceeds it.
 - Normalize client-side before submission, replacing `s` with `n − s` whenever `s > n/2`.
 
 Applications whose replay protection lives in the signed message itself (for example, an included nonce) are unaffected, because a malleated signature still authenticates the same message.

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -8,7 +8,7 @@ Type: Runtime Spec
 Category: Protocol
 Version: 1.0.0
 Created: 2026-01-24
-Last Updated: 2026-01-24
+Last Updated: 2026-07-06
 ---
 
 ## Summary
@@ -100,7 +100,22 @@ The reference implementation in `nearcore`:
 
 ## Security Implications (Optional)
 
+### Prehashing
+
 This host function does not perform hashing or domain separation. Callers MUST ensure that the message passed to `p256_verify` follows the correct protocol (for example, WebAuthn uses SHA-256 over the signed data). The runtime only checks signature and key encoding constraints as specified above.
+
+### Signature malleability
+
+ECDSA signatures are inherently malleable: for any valid signature `(r, s)`, the value `(r, n − s)` (where `n` is the P-256 curve order) is also a valid signature over the same message and public key. `p256_verify` accepts both forms. Verification follows FIPS 186-5 and does NOT enforce low-s normalization; low-s is a Bitcoin [BIP-62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) convention, not part of the ECDSA standard.
+
+This is a deliberate choice. WebAuthn does not require low-s, and widely deployed authenticators (for example, Apple's Secure Enclave) routinely emit high-s signatures; enforcing low-s at the host-function level would reject authentic passkey signatures. It also matches Ethereum's [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) `P256VERIFY` precompile, which made the same choice for the same reason. Unlike NEAR's existing `ecrecover` host function, which takes a `malleability_flag` argument, `p256_verify` deliberately takes no such flag. The reference implementation pins this behavior with a [Wycheproof](https://github.com/C2SP/wycheproof)-based regression test so that low-s enforcement cannot be introduced accidentally.
+
+Malleability is only a concern for applications that derive uniqueness or replay protection from the signature bytes themselves (for example, using a hash of the signature as a nullifier). Such applications MUST take one of the following measures:
+
+- Enforce low-s in the contract. With the raw `r || s` encoding, `s` occupies bytes 32..64 of the signature (big-endian), so the check is a byte comparison of that value against ⌊n/2⌋ = `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8`, rejecting signatures whose `s` exceeds it.
+- Normalize client-side before submission, replacing `s` with `n − s` whenever `s > n/2`.
+
+Applications whose replay protection lives in the signed message itself (for example, an included nonce) are unaffected, because a malleated signature still authenticates the same message.
 
 ## Unresolved Issues (Optional)
 

--- a/neps/nep-0635.md
+++ b/neps/nep-0635.md
@@ -106,14 +106,14 @@ This host function does not perform hashing or domain separation. Callers MUST e
 
 ### Signature malleability
 
-ECDSA signatures are inherently malleable: for any valid signature `(r, s)`, the value `(r, n − s)` (where `n` is the P-256 curve order) is also a valid signature over the same message and public key. `p256_verify` accepts both forms. Verification follows FIPS 186-5 and does NOT enforce low-s normalization; low-s is a Bitcoin [BIP-62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) convention, not part of the ECDSA standard.
+ECDSA signatures are inherently malleable: for any valid signature `(r, s)`, the value `(r, n - s)` (where `n` is the P-256 curve order) is also a valid signature over the same message and public key. `p256_verify` accepts both forms. Verification follows FIPS 186-5 and does NOT enforce low-s normalization; low-s is a Bitcoin [BIP-62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) convention, not part of the ECDSA standard.
 
 This is a deliberate choice. WebAuthn does not require low-s, and widely deployed authenticators (for example, Apple's Secure Enclave) routinely emit high-s signatures; enforcing low-s at the host-function level would reject authentic passkey signatures. It also matches Ethereum's [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) `P256VERIFY` precompile, which made the same choice for the same reason. Unlike NEAR's existing `ecrecover` host function, which takes a `malleability_flag` argument, `p256_verify` deliberately takes no such flag. The reference implementation pins this behavior with a [Wycheproof](https://github.com/C2SP/wycheproof)-based regression test so that low-s enforcement cannot be introduced accidentally.
 
 Malleability is only a concern for applications that derive uniqueness or replay protection from the signature bytes themselves (for example, using a hash of the signature as a nullifier). Such applications MUST take one of the following measures:
 
 - Enforce low-s in the contract. With the raw `r || s` encoding, `s` is the last 32 bytes of the 64-byte signature (offset 32, length 32), interpreted as a big-endian integer, so the check is a byte comparison of that value against ⌊n/2⌋ = `0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8`, rejecting signatures whose `s` exceeds it.
-- Normalize client-side before submission, replacing `s` with `n − s` whenever `s > n/2`.
+- Normalize client-side before submission, replacing `s` with `n - s` whenever `s > n/2`.
 
 Applications whose replay protection lives in the signed message itself (for example, an included nonce) are unaffected, because a malleated signature still authenticates the same message.
 


### PR DESCRIPTION
NEP-635's Security Implications section covers message prehashing but is silent on ECDSA signature malleability. This amendment documents the already-shipped behavior: `p256_verify` follows FIPS 186-5 and accepts both low-s and high-s signatures (it does not enforce BIP-62 low-s normalization), matching WebAuthn/Secure Enclave reality and Ethereum's RIP-7212 precompile.

It adds guidance for the only affected case — applications that derive uniqueness or replay protection from the signature bytes — showing how to enforce low-s in-contract (byte comparison of `s` against ⌊n/2⌋) or normalize client-side. No semantic or normative change to the protocol; this is a clarifying amendment to an existing Draft NEP.