### PR TITLE
ci: ignore iso.org in markdown-link-check

### DIFF
--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -20,6 +20,9 @@
     },
     {
       "pattern": "^https://eprint\\.iacr\\.org/"
+    },
+    {
+      "pattern": "^https://www\\.iso\\.org/"
     }
   ],
   "timeout": "20s",

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -22,7 +22,7 @@
       "pattern": "^https://eprint\\.iacr\\.org/"
     },
     {
-      "pattern": "^https://www\\.iso\\.org/"
+      "pattern": "^https://(www\\.)?iso\\.org/"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
iso.org returns 403 to the link checker (bot blocking), so `markdown-link-check` fails on every PR via the ISO 8601 link in nep-0177.md — e.g. https://github.com/near/NEPs/actions/runs/28804799935/job/85417419410. Adds it to the existing ignore list alongside the other bot-blocking hosts; the link itself works fine in a browser.