### PR TITLE
NEP-652: Early Chunk Producer Reassignment

### DIFF
--- a/neps/nep-0000.md
+++ b/neps/nep-0000.md
@@ -1,0 +1,848 @@
+---
+NEP: 0
+Title: Early Chunk Producer Reassignment
+Authors: Stefan Neamtu <stefan.neamtu@nearone.org>
+Status: Draft
+DiscussionsTo: https://github.com/near/NEPs/pull/0000
+Type: Protocol
+Version: 1.0.0
+Created: 2026-08-17
+LastUpdated: 2026-08-17
+---
+
+## Summary
+
+This proposal does not directly remove a validator from the validator set. It deterministically
+excludes a persistently failing chunk producer from future chunk-slot assignment on its shard for
+the remainder of the epoch, instead of letting its slots go on being missed until the epoch
+boundary. (The implementation names the feature `ProtocolFeature::EarlyKickout`; this document
+uses *reassignment* for the mechanism and reserves *kickout* for the existing end-of-epoch rules.)
+
+Today a chunk producer that goes offline mid-epoch keeps its share of that shard's chunk slots
+until the epoch ends, because the existing kickout only reacts at epoch finalization. For a fully
+unavailable producer every such slot is a missed chunk, so a shard can spend most of an epoch
+producing at a fraction of its nominal rate.
+
+This proposal derives a per-shard *exclusion set* — a *blacklist* — from the in-epoch chunk
+statistics the protocol already aggregates: a producer is excluded on a shard once it has missed
+at least 100 chunks there in the current epoch *and* its inclusion ratio is below 80%. Its future
+slots go to the remaining eligible producers by the existing stake-weighted rule. A keep-one
+safety valve guarantees a shard always retains one eligible producer, and a 1000-block
+start-of-epoch grace window absorbs coordinated restarts such as protocol upgrades. The mechanism
+is deterministic: the decision basis is a finality-derived block, and the resolved producer for
+each chunk is persisted and read back verbatim.
+
+The principal trade-offs are one new storage column and a hot-path read, higher load on the
+remaining producers, and exclusion that is sticky for the rest of the epoch regardless of cause —
+freezing the producer's chunk statistics and thereby locking in the end-of-epoch kickout outcome.
+
+## Motivation
+
+Chunk production availability is currently protected by a single, epoch-granular control:
+`chunk_producer_kickout_threshold`. At the end of an epoch, a producer whose
+`produced_chunks / expected_chunks` ratio is below the threshold is kicked out of the validator
+set for the following epoch. [NEP-509](https://github.com/near/NEPs/blob/master/neps/nep-0509.md)
+("Stateless validation Stage 0") describes this kickout family and extends it to chunk validators.
+
+That control is a *rotation* mechanism, not a *liveness* mechanism. It answers "should this node
+keep its seat next epoch?". It does not answer "what should the shard do for the rest of this
+epoch?". The gap this leaves is concrete:
+
+* A chunk producer that crashes early in an epoch keeps being sampled for its shard's chunk slots
+  for the remainder of the epoch. On mainnet-scale epochs that is on the order of tens of
+  thousands of block heights.
+* For a fully unavailable producer, every one of those slots is a missed chunk on that shard. The
+  shard still advances (block production is unaffected), but its transactions and receipts are not
+  processed at those heights, so the shard's effective throughput drops in proportion to the
+  failing producer's share of the settlement.
+* The impact is *per shard*. A producer assigned to one shard degrades that shard specifically,
+  which makes the user-visible effect uneven across the network.
+* The failure does not have to be adversarial. Hardware failure, a bad deploy, a network partition
+  affecting one operator, or an unusually long upgrade restart all produce the same shape.
+
+With four producers `A B C D` rotating on a shard and `C` failing mid-epoch, the shard looks like
+this today (`X` marks a missed chunk):
+
+```
+A B C D A B C D A B C D ...
+    ^ C fails
+A B X D A B X D A B X D ...     until the epoch boundary
+```
+
+and like this with in-epoch reassignment, once the failure has been detected:
+
+```
+A B X D A B X D A B D A B D ...
+                ^ C's slots reassigned to the survivors
+```
+
+Reassigning those slots mid-epoch converts a long tail of guaranteed misses into chunks produced
+by healthy producers. The protocol already computes, per epoch and per shard, the
+`(produced, expected)` counters this decision needs; what is missing is a rule that consumes them
+before the epoch boundary and a deterministic way for every node to agree on the resulting
+assignment.
+
+NEP-509 also documents a limitation that motivates the shape of this proposal rather than its
+existence: chunk validator quality is measured by `included_chunks / expected_chunks` rather than
+by endorsements, because the endorsement mask is not part of the block header. This proposal
+deliberately stays within the signals that *are* header-derived and already aggregated, so it
+introduces no new consensus inputs. Closing NEP-509's endorsement-blind gap is listed under
+Future possibilities.
+
+## Specification
+
+### Concepts
+
+**Chunk production statistics.** For each epoch, the protocol aggregates per shard and per
+validator a pair of counters, `produced` and `expected`, over the blocks of that epoch. These are
+the same counters that feed end-of-epoch kickouts. `missed` is defined as
+`expected - produced` (saturating at zero), and the *inclusion ratio* is `produced / expected`.
+Note that, as NEP-509 records, `produced` in fact counts chunks *included in blocks*: the block
+producer makes the final inclusion decision, so a chunk that was produced but not delivered, not
+validated in time, or simply not included counts as missed all the same. This proposal inherits
+that property of the signal; its consequences are discussed under Security Implications.
+
+**Chunk producer settlement.** The per-shard sequence of chunk producers that validator selection
+assigned to a shard for the epoch; the canonical sampler draws each height's producer from it.
+The *distinct producers of a shard* are the set of validator ids appearing in that shard's
+settlement. The statistics map also carries entries for validators that only endorsed chunks on
+the shard and never produced any; those entries MUST NOT be treated as producers.
+
+**Block info.** The per-block record of consensus metadata — height, epoch id, the last-final
+hash, and so on — that every node persists for every block it processes.
+
+**Last-final block.** The most recent block that is final under Doomslug as of a given block,
+recorded in that block's info. It is a function of the block's header, so every node derives the
+same last-final block for the same block.
+
+**Anchor.** For a chunk at height `H` built on parent block `P`, the anchor `A` is `P`'s parent,
+i.e. the chunk's *grandparent*. `A.height + 2` is the height used for sampling. `A` is the key
+under which the resolved producer is persisted and looked up. The grandparent, rather than the
+parent, is the anchor because chunks are produced and distributed concurrently with the
+propagation of their parent block: a node must be able to resolve a chunk's producer — to verify
+its signature — before it has fully processed `P`, and the grandparent is the newest block it is
+guaranteed to have processed by then.
+
+**Basis.** The last-final block of the anchor, as recorded in the anchor's block info. All
+blacklist computation is performed against the statistics aggregated up to and including the
+basis.
+
+### Exclusion rule
+
+For a given basis and a given epoch, the per-shard exclusion set — the *blacklist*, hereafter —
+is computed as follows.
+
+For each shard `s` in the epoch's shard layout, and each validator `v` that is a distinct producer
+of `s`, with `(produced, expected)` its in-epoch statistics on `s`:
+
+```
+missed = saturating_sub(expected, produced)
+
+v is a blacklist candidate on s  iff
+    missed >= EARLY_KICKOUT_MIN_MISSES              (= 100)
+  and
+    produced * 100 < expected * 80                  (inclusion ratio < 80%)
+```
+
+The ratio comparison MUST be evaluated with integer arithmetic wide enough not to overflow
+(the reference implementation widens both sides to `u128`); floating point MUST NOT be used,
+because the result is consensus-relevant.
+
+Validators that are not distinct producers of `s` are neither candidates nor counted in the
+safety valve denominator below. A validator with `expected == 0` on a shard can never be a
+candidate, because the 100-miss floor is unreachable without expected slots.
+
+### Keep-one safety valve
+
+If, for a shard `s`, every distinct producer of `s` is a blacklist candidate, then exactly one
+producer — the *least bad* — is removed from the candidate set and remains eligible. A shard is
+therefore never left without an eligible chunk producer.
+
+The least-bad producer is the maximum under this deterministic total order over candidates
+`a`, `b` with statistics `(p_a, e_a)` and `(p_b, e_b)`:
+
+1. Higher inclusion ratio wins. Compared as `p_a * e_b` versus `p_b * e_a` (integer
+   cross-multiplication; no division, no floating point).
+2. Tie: fewer `expected` wins — at an equal ratio, the producer with fewer expected slots has
+   offered less evidence of failure.
+3. Tie: lower validator id wins.
+
+The order MUST be total and MUST NOT depend on hash map or set iteration order, since the result
+feeds sampling and therefore consensus.
+
+A shard with a single distinct producer degenerates to the same rule: the single producer is kept
+and the shard's blacklist is empty.
+
+The valve guarantees exactly one thing: the eligible set handed to the sampler is never empty. It
+does not guarantee shard liveness, and it does not preserve the original assignment distribution.
+If every producer on a shard is a candidate, the retained producer receives *all* subsequent chunk
+slots on that shard and may be unable to sustain that load. More generally, excluding producers
+that hold a fraction `x` of the shard's eligible stake multiplies every survivor's expected
+assignment rate by `1 / (1 - x)`; sustained partial failures can therefore concentrate load, and
+in the extreme push borderline survivors over the exclusion thresholds themselves. This is an
+explicit worst-case trade-off: the protocol prefers one deterministic eligible producer over
+either an undefined empty-set assignment or re-including producers whose chunks are currently not
+landing at all. Softer variants are discussed under Alternatives.
+
+### Start-of-epoch grace
+
+Let `epoch_start` be the height of the first block of the basis's epoch and
+`blocks_into_epoch = basis.height - epoch_start` (saturating).
+
+```
+if blocks_into_epoch < EARLY_KICKOUT_EPOCH_GRACE_BLOCKS   (= 1000)
+    blacklist is empty
+```
+
+Statistics never cross epoch boundaries: the aggregation is per epoch and resets at each boundary.
+Consequently every epoch starts with empty statistics, and the grace window then delays any
+blacklisting for a further 1000 blocks. The window exists so that a network-wide restart — most
+importantly a protocol upgrade, which lands on an epoch boundary — cannot cause the whole
+validator set to be blacklisted at once for downtime that is expected and short-lived.
+
+Statistics accrue *during* the grace window; only the exclusion output is suppressed. A producer
+that fails from the first block of an epoch can therefore be excluded as soon as the basis passes
+the 1000-block mark: the grace window delays the first possible exclusion, it does not delay the
+evidence-gathering behind it.
+
+Additionally, if the aggregated statistics available at the basis belong to a different epoch than
+the epoch being sampled, the blacklist MUST be empty. This is the normal state for the first
+blocks of an epoch, where the anchor's last-final block still lies in the previous epoch. The two
+epochs legitimately differ, and prior-epoch statistics MUST NOT be applied to the current epoch:
+validator ids are epoch-local indices, so reusing them across a boundary would blacklist whichever
+validators happen to occupy those indices.
+
+### Detection latency
+
+The two thresholds are an evidence floor, not a detection bound. How long detection takes depends
+on the producer's history and on its share of the shard's slots.
+
+The ratio requirement scales with earlier good performance. A producer that was perfect for `E₀`
+assigned slots and then fails completely needs
+
+```
+misses required = max(100, floor(E₀ / 4) + 1)
+```
+
+missed chunks before its inclusion ratio drops below 80%:
+
+| Slots produced before failing (`E₀`) | Misses required |
+| -----------------------------------: | --------------: |
+|                                    0 |             100 |
+|                                1,000 |             251 |
+|                                4,000 |           1,001 |
+
+Accruing `m` missed slots takes roughly `m / q` block heights for a producer holding a fraction
+`q` of the shard's assignments, plus the lag of finality and the grandparent anchor. A producer
+that fails late in an epoch, with a long good history behind it, therefore remains scheduled for
+considerably more than 100 misses. This is intentional: earlier good performance buys tolerance,
+and the mechanism targets sustained failure, not a fixed reaction time.
+
+### Assignment
+
+For a chunk on shard `s` whose anchor is `A`:
+
+1. Compute the blacklist for shard `s` as of `A`'s basis, in `A`'s own epoch.
+2. Sample a producer at height `A.height + 2` from `s`'s settlement *excluding* the blacklisted
+   validators:
+   * For epoch info versions that select by height modulo, filter the settlement by the exclusion
+     set first, then apply the modulo rule to the filtered sequence.
+   * For stake-weighted epoch info versions, build a fresh stake-weighted distribution over the
+     surviving producers only — i.e. the stake weights are renormalized over the survivors — and
+     sample it with the same per-`(shard, height)` seed the canonical sampler uses.
+   * An empty exclusion set MUST resolve identically to the canonical sampler, so behaviour is
+     unchanged whenever no producer is blacklisted.
+3. Persist the resulting producer keyed by `(A, s)`.
+
+Every protocol version that can activate this feature uses stake-weighted selection; the
+filtered-modulo rule is specified for completeness across older epoch info versions only.
+
+Chunks whose epoch differs from their anchor's epoch — that is, chunks within the first two blocks
+of an epoch — are resolved with the canonical sampler. At those heights the blacklist is provably
+empty (statistics have just reset and the grace window applies), so the two paths agree. Chunks
+with no anchor at all — a chunk at genesis or at genesis + 1, where no grandparent exists — also
+resolve canonically.
+
+### Worked example
+
+A shard with four distinct producers, past the grace window, with these statistics at the basis:
+
+| Producer | Stake | Produced | Expected | Missed | Ratio | Candidate             |
+| :------- | ----: | -------: | -------: | -----: | ----: | :-------------------- |
+| A        |    40 |      450 |      500 |     50 | 90.0% | no (under 100 misses) |
+| B        |    30 |      350 |      500 |    150 | 70.0% | yes                   |
+| C        |    20 |      390 |      500 |    110 | 78.0% | yes                   |
+| D        |    10 |      490 |      500 |     10 | 98.0% | no                    |
+
+B and C are blacklisted. Future slots on the shard are sampled stake-weighted over the survivors:
+A with weight `40 / (40 + 10) = 80%`, D with `10 / (40 + 10) = 20%`.
+
+If instead all four were candidates — say A at `380 / 500` and D at `350 / 500`, with B and C as
+above — the keep-one valve compares inclusion ratios by integer cross-multiplication and keeps C,
+whose 78% is the highest; A, B, and D are blacklisted and C receives every subsequent slot on the
+shard.
+
+### Determinism and resolution
+
+The persisted assignment, not a recomputation, is authoritative within a node:
+
+* Every node writes the row for `(A, s)` when it processes `A`, in the same atomic store update as
+  `A`'s block info.
+* When a node needs the producer of a chunk anchored at `A`, it reads the row for `(A, s)` and uses
+  it **verbatim**. It does not recompute the blacklist at read time.
+* If the row is absent while the feature is active and the anchor's epoch equals the chunk's epoch,
+  resolution MUST **fail closed** with a distinct error rather than falling back to the canonical
+  sampler. Falling back would silently resolve a different producer than the rest of the network.
+
+The row is materialized consensus-derived state, not a globally committed value. Persistence
+prevents readers within one node from recomputing the assignment against a different local view
+(fork visibility, garbage collection, sync mode); it does not by itself make two nodes agree.
+Agreement between nodes rests on every node deriving the same row from the same inputs — the
+invariant, for any active protocol version, anchor `A`, and shard `s`:
+
+```
+derive_assignment(A, s) is a deterministic function of (A, s, protocol version), and
+stored_assignment[A, s] == derive_assignment(A, s)
+```
+
+Determinism of the derivation rests on the basis being *finality-derived*. The anchor's last-final
+block is a function of the anchor's header, so for a canonical anchor every node sees the same
+basis and therefore computes the same blacklist, regardless of what else that node has seen. Using
+the anchor itself, or the node's local head, would make the result depend on fork visibility.
+
+Two further requirements follow:
+
+* The epoch start height used by the grace check MUST be derived by walking block info from the
+  basis, not read from a per-epoch shared record. Sibling blocks at an epoch boundary overwrite
+  such a shared record, which would make the grace decision depend on the order in which a node
+  happened to process forks.
+* The writer (which seeds the row) and any live reader of the blacklist MUST share one
+  implementation of the basis and of the reset/grace checks, so the stored row and a live
+  computation cannot drift apart.
+
+### Interaction with end-of-epoch kickout and rewards
+
+Because the aggregated `expected` counters follow the assignment that consensus actually resolved,
+a blacklisted producer stops accruing `expected` on that shard. Its inclusion ratio there freezes
+at the value it had when exclusion took effect, and exclusion is in practice sticky for the
+remainder of the epoch: with no new expected slots, the statistics that caused it cannot improve.
+
+This has a consequence beyond assignment, and it is a deliberate design decision of this proposal
+rather than a side effect. The frozen counters are the same counters the end-of-epoch kickout and
+the reward calculation read. Consider a producer excluded at `produced = 399, expected = 500` — an
+inclusion ratio of 79.8%. Had it recovered immediately and produced its next 500 assigned slots,
+it would have finished the epoch at `899 / 1000 = 89.9%` and kept its seat. Excluded, it finishes
+at 79.8%. With `chunk_producer_kickout_threshold` at 80% or above, an excluded producer therefore
+also fails the boundary kickout — mid-epoch exclusion locks in the end-of-epoch result, and with
+it the loss of the epoch's rewards, since kicked-out validators are not rewarded. The proposal
+accepts this: a producer that has missed at least 100 chunks and dropped below the boundary
+threshold has already demonstrated the failure the boundary rule exists to catch, and an epoch of
+lost slots for the shard is the wrong price for preserving its chance to recover on paper.
+
+Three boundaries of this effect are worth stating precisely:
+
+* It is per shard. A producer excluded on one shard keeps accruing `produced` and `expected` on
+  any other shard it is assigned to, and the boundary kickout sums a validator's statistics across
+  shards. The lock-in is exact for a producer whose only chunk assignment is the affected shard —
+  the common case.
+* Only the chunk statistics freeze. Block production and endorsement statistics keep accruing, so
+  the overall online ratio that feeds the reward calculation is not fully frozen.
+* The lock-in holds only for boundary thresholds at or below the exclusion ratio. This proposal
+  reuses 80% precisely so the two rules agree; a chain configured with a boundary threshold below
+  80% could see an excluded producer freeze *above* the bar and keep its seat on truncated
+  statistics.
+
+The producer regains its slots at the next epoch boundary, where the end-of-epoch rules decide —
+on the frozen statistics — whether it keeps its seat at all. An alternative that decouples
+assignment from these statistics is discussed under Alternatives, and a probe mechanism that lets
+a recovered producer return mid-epoch under Future possibilities.
+
+### Parameters
+
+| Parameter | Value | Rationale |
+| :-------- | ----: | :-------- |
+| `EARLY_KICKOUT_MIN_MISSES` | 100 | Absolute floor on evidence. A producer with a handful of misses — a brief network blip, a single slow block — must not be reassigned. 100 missed chunks on one shard is a sustained failure, not noise, and it bounds how often the mechanism can trigger at all. |
+| Inclusion ratio threshold | 80% | Matches the ratio already used by the end-of-epoch kickout family (NEP-509 uses 0.8 for block producers, chunk producers, and chunk-validator-only nodes). Reusing it keeps the two mechanisms consistent on the same statistics; see Interaction with end-of-epoch kickout and rewards. |
+| `EARLY_KICKOUT_EPOCH_GRACE_BLOCKS` | 1000 | Absorbs correlated start-of-epoch downtime, primarily protocol-upgrade restarts, which land on epoch boundaries and affect the whole validator set at once. Without it a slow network-wide restart could blacklist many producers simultaneously in the first blocks of an epoch. |
+
+The two thresholds are conjunctive, so both a large absolute failure count and a low ratio are
+required; see Detection latency for what that means in time. The values were chosen after
+soliciting feedback from validators, who accepted them
+<!-- TODO(author): link the validator feedback venue/thread if public -->. In the reference
+implementation all three are compile-time constants of the epoch manager — not epoch config
+fields, not operator-tunable, and not per-chain. One consequence is that chains whose epochs are
+shorter than or close to `EARLY_KICKOUT_EPOCH_GRACE_BLOCKS` — common for test networks — never
+leave the grace window, and the mechanism is inert there by construction.
+
+### Assumptions, invariants, and scope
+
+This proposal assumes:
+
+* The remaining eligible producers can absorb the reassigned chunk-production load.
+* Header-derived inclusion statistics are an adequate signal for availability remediation; they
+  are not fault attribution (see Security Implications).
+* Every consensus-path lookup for an active, same-epoch chunk has a seeded assignment row.
+* Every shard's settlement contains at least one distinct producer.
+* The companion network message changes activate at the same protocol version as the feature (see
+  Network message compatibility).
+
+It maintains these invariants:
+
+* An empty exclusion set resolves identically to the canonical sampler.
+* At least one producer remains eligible on every shard.
+* Validator ids are never interpreted across epoch boundaries.
+* The writer and every reader share one implementation of the basis and of the reset and grace
+  checks.
+* The same anchor, shard, and protocol version always yield the same assignment.
+* A missing assignment row on an active, same-epoch consensus path is an error, never a fallback.
+
+Out of scope:
+
+* Slashing, or any cryptographic attribution of fault.
+* Changes to the reward rules; the indirect effect through frozen counters is documented above.
+* Re-entry of an excluded producer during the same epoch.
+* Block producer reassignment.
+* Endorsement-based failure detection.
+* Public APIs exposing the blacklist.
+* Trailing-window or consecutive-miss detection (see Alternatives).
+
+## Reference Implementation
+
+The mechanism is implemented in nearcore behind `ProtocolFeature::EarlyKickout`, which this proposal
+assigns a stable protocol version. The description below is of the shipping implementation.
+
+### Storage
+
+A dedicated column, `DBCol::ChunkProducers`, holds the resolved assignments.
+
+* Key: `block_hash || shard_id` (40 bytes), where `block_hash` is the anchor.
+* Value: the resolved `ValidatorStake`.
+* Rows are written inside the same store update as the anchor's `BlockInfo`, so a block's
+  assignments commit atomically with the block itself.
+* Rows are garbage collected with the rest of a block's data.
+* The column is a cold column: on archival nodes its rows are copied to cold storage alongside the
+  rest of a block's data.
+
+Registering the column carries a database version bump and migration; see Backwards Compatibility.
+
+### Interfaces
+
+The consensus-facing entry point takes the anchor explicitly:
+
+```rust
+fn get_chunk_producer_info_anchored(
+    &self,
+    anchor: Option<&CryptoHash>,
+    chunk_epoch_id: &EpochId,
+    height_created: BlockHeight,
+    shard_id: ShardId,
+) -> Result<ValidatorStake, EpochError>;
+```
+
+with a convenience wrapper that derives `(chunk_epoch_id, height_created, anchor)` from the chunk's
+parent block. `anchor: None` (a chunk at genesis or genesis + 1) and a cross-epoch anchor both
+route to the canonical sampler. A missing row on the in-epoch path yields
+`EpochError::ChunkProducerNotInDB(anchor, shard_id)`.
+
+The blacklist itself is computed by a pure function over the aggregated statistics, the epoch info,
+and the shard layout, returning the per-shard exclusion sets plus per-shard statistics used only
+for metrics and logging.
+
+Exclusion sampling is a sibling of the canonical sampler:
+
+```rust
+fn sample_chunk_producer_excluding(
+    &self,
+    shard_layout: &ShardLayout,
+    shard_id: ShardId,
+    height: BlockHeight,
+    exclude: &HashSet<ValidatorId>,
+) -> Option<ValidatorId>;
+```
+
+It short-circuits to the canonical sampler when `exclude` is empty.
+
+### Corner cases
+
+* **Genesis and the first two blocks of an epoch.** No anchor, or an anchor in the previous epoch.
+  Both resolve canonically; the blacklist is empty there by construction.
+* **Epoch sync.** A node that joins by epoch sync installs the current epoch's first block outside
+  the normal block-processing path. That block's rows are seeded with an empty blacklist, which is
+  correct because an epoch's first block has no in-epoch statistics yet.
+* **Statistics aggregation.** The aggregation of `(produced, expected)` itself resolves producers
+  through the anchor, so the counters track the producers consensus actually used rather than the
+  canonical sampler's picks. On this path a missing row falls back to canonical sampling — but the
+  fallback is permitted only in states where canonical and anchored resolution are provably
+  identical: before activation, at genesis, for a cross-epoch anchor, and for the
+  epoch-sync-seeded first block of an epoch, all of which have an empty blacklist by construction.
+  The governing invariant is that the set of anchors that can be missing a row and the set of
+  anchors with a non-empty blacklist are disjoint; the implementation pins this with a dedicated
+  test.
+* **Resharding.** Rows are seeded over the anchor's own epoch's shard layout, so a retired shard
+  simply stops receiving rows from the first post-reshard anchor onward.
+* **Safety valve exhaustion.** The exclusion sampler returning `None` for a shard that has
+  producers would mean the safety valve was violated; the reference implementation asserts against
+  this in debug builds.
+
+### Failure and recovery
+
+Failing closed is the right consensus-safety default; this is its operational story:
+
+* **What fails.** A missing row on the consensus path yields
+  `EpochError::ChunkProducerNotInDB(anchor, shard_id)`, and whatever operation needed the producer
+  — chunk signature verification, witness validation — fails with it. The node refuses to guess
+  rather than resolve a producer the rest of the network may disagree with.
+* **How it surfaces.** The error is distinct, and the anchored-lookup metric (see Observability)
+  labels row-missing lookups separately from other outcomes, so the condition is visible when it
+  first occurs.
+* **Recovery.** Rows commit atomically with the anchor's block info, so a missing row for a block
+  whose info is present indicates database corruption rather than a normal gap. The row content is
+  deterministically re-derivable from chain state; in practice recovery is the same as for any
+  corrupted consensus column — reprocess the affected range or resync. Nodes joining by epoch sync
+  or state sync have their required rows seeded as described under Corner cases, and the seeding
+  is covered by tests.
+
+### Observability
+
+Per-shard metrics: blacklist size, safety-valve firings, chunk producer slot reassignments, and a
+labelled counter for anchored lookups (hit, anchor block missing, row missing, error). Metrics are
+emitted by the writer only, never by the read path, so a consensus read cannot double count.
+
+### Pull requests
+
+The mechanism landed in nearcore across the following pull requests:
+
+| PR | Contribution |
+| :-- | :---------- |
+| [#15841](https://github.com/near/nearcore/pull/15841) | Blacklist math and exclusion sampling |
+| [#15639](https://github.com/near/nearcore/pull/15639) | Witness V2 wire types and network plumbing |
+| [#15908](https://github.com/near/nearcore/pull/15908) | Grandparent-anchored producer resolution (witness V2 path) |
+| [#15843](https://github.com/near/nearcore/pull/15843) | Feature enablement, `DBCol::ChunkProducers`, anchored reader, keep-one safety valve |
+| [#15931](https://github.com/near/nearcore/pull/15931) | Contract-accesses V2 anchored on the grandparent |
+| [#15932](https://github.com/near/nearcore/pull/15932) | Contract-deploys V2 anchored on the grandparent |
+| [#15944](https://github.com/near/nearcore/pull/15944) | Single writer for the column, folded into block recording |
+| [#16012](https://github.com/near/nearcore/pull/16012) | `ChunkProducers` as a cold column |
+| [#16023](https://github.com/near/nearcore/pull/16023) | Garbage collection of `ChunkProducers` with block data |
+| [#16049](https://github.com/near/nearcore/pull/16049) | Production threshold tuning |
+| [#16072](https://github.com/near/nearcore/pull/16072) | Blacklist basis moved to the anchor's last-final block |
+| [#16125](https://github.com/near/nearcore/pull/16125) | Epoch-sync bootstrap seeding, end-to-end tests |
+| [#16139](https://github.com/near/nearcore/pull/16139) | Fork-order-independent epoch start for the grace check |
+| [#16197](https://github.com/near/nearcore/pull/16197) | Cache eviction when block recording fails |
+
+Test coverage additionally in [#15983](https://github.com/near/nearcore/pull/15983) (behaviour
+across state sync) and [#16219](https://github.com/near/nearcore/pull/16219) (resharding and
+abandoned forks).
+
+## Security Implications
+
+### Consensus safety
+
+The central risk of any mid-epoch reassignment is nodes disagreeing on who was supposed to produce
+a chunk. A disagreement here is not a degraded shard; it is a chain split, because chunk producer
+identity gates chunk and witness signature verification.
+
+The design addresses this in three ways:
+
+1. **The basis is finality-derived, not local.** The blacklist is computed against the anchor's
+   last-final block, which is a function of the anchor's header. Every node that has the anchor has
+   the same basis, independent of which forks it has seen or in what order.
+2. **Rows are read verbatim.** The read path performs no recomputation, so all consumers within a
+   node agree with each other and with what the node's writer derived. Combined with the
+   deterministic derivation (see Determinism and resolution), nodes that processed the same anchor
+   hold the same row.
+3. **Reads fail closed.** A missing row on the in-epoch path is an error, not a fallback. A node
+   that cannot resolve the assignment refuses to make a decision rather than making a different one
+   from the rest of the network.
+
+Supporting requirements — one shared implementation of the basis for writer and reader, and an
+epoch start derived by walking block info rather than reading a fork-shared record — exist
+specifically to keep these three properties from drifting apart. Both were tightened during
+implementation ([#16072](https://github.com/near/nearcore/pull/16072),
+[#16139](https://github.com/near/nearcore/pull/16139)).
+
+### Liveness of a shard
+
+Exclusion cannot empty a shard: the keep-one safety valve is evaluated before the blacklist is
+applied, and the exclusion sampler is only ever given a set that leaves at least one producer.
+That is the whole guarantee. In the worst case — every producer on a shard a candidate — the
+retained least-bad producer receives all of the shard's subsequent slots, which it may or may not
+be able to sustain; the shard's liveness then rests on one node, as it would if the shard had been
+assigned a single producer to begin with. The valve prefers that deterministic outcome over an
+undefined empty-set assignment; it does not claim the outcome is good. The load-concentration
+trade-off is quantified under Keep-one safety valve, and softer variants are discussed under
+Alternatives.
+
+### Signal quality and targeted suppression
+
+The exclusion rule reacts to observed chunk *non-inclusion*, not to cryptographic proof that the
+assigned producer was at fault. As noted under Concepts, the `produced` counter counts chunks
+included in blocks, and the block producer makes the final inclusion decision. A missing chunk may
+therefore mean producer unavailability, a network failure between the producer and the rest of the
+network, a chunk that failed distribution or validation in time, or non-inclusion by block
+producers. The mechanism is availability remediation, not fault attribution, and exclusion under
+this proposal MUST NOT be treated as evidence of misbehaviour suitable for slashing or any other
+punitive mechanism.
+
+It follows that exclusion is not entirely outside third-party influence. An adversary that can
+suppress a producer's chunks for the observation window — most plausibly block producers refusing
+to include them — can push a healthy producer over the thresholds and, because exclusion is
+sticky, keep it out for the remainder of the epoch. Two things bound this: the same suppression
+already drives the end-of-epoch kickout through the same counters, so the attack surface is not
+new — this proposal makes its effect earlier and, within the epoch, irreversible; and suppression
+at that scale is visible in the same public, auditable statistics.
+
+The converse direction is closed: a producer cannot use self-exclusion to escape the boundary
+rules, because exclusion requires an inclusion ratio already below 80%, and freezing it there
+still fails a boundary threshold at 80% or above (see Interaction with end-of-epoch kickout and
+rewards).
+
+Reassignment concentrates a shard's remaining slots on the surviving producers. Under
+stake-weighted selection this is the distribution the protocol would have used had the excluded
+producers not been in the settlement, so no new concentration rule is introduced — but the
+absolute load on each survivor rises, as quantified under Keep-one safety valve.
+
+### Message handling before the parent block is known
+
+Chunk producer resolution is also reached from the best-effort path that handles chunk-related
+messages whose parent block a node has not yet processed. That path is non-consensus: it only
+decides whether to do early work on a message, and every such message is validated again on the
+normal parent-known path before it can affect block or chunk validation. Messages there are
+constrained to a chunk height exactly two above the claimed anchor, must carry a valid chunk
+producer signature for the referenced epoch and shard, and are dropped rather than resolved
+whenever the claimed anchor could sit at an epoch tail, where the claimed epoch would not
+determine the producer.
+
+## Alternatives
+
+### Do nothing: rely on end-of-epoch kickout
+
+The status quo. A failing producer is removed at the epoch boundary and the shard absorbs the
+misses until then.
+
+Rejected because the cost is bounded only by the remaining epoch length — there is no independent
+failure-detection bound — and it falls entirely on one shard's users. The information needed to
+act earlier is already present; the only thing missing is a rule to act on it.
+
+### Recompute the assignment on every read, without persistence
+
+Skip the column and have each node recompute the blacklist whenever it needs to know a chunk's
+producer.
+
+Rejected on two grounds. First, correctness: a recomputation is only as deterministic as the state
+it reads, and read-time state differs across nodes and over time (fork visibility, garbage
+collection, sync mode). Persisting the decision at the moment the anchor is processed removes that
+class of divergence entirely. Second, cost: chunk producer resolution is on the signature
+verification hot path, and the blacklist computation requires walking aggregated statistics — that
+is not acceptable per lookup.
+
+### React to a single missed chunk
+
+Blacklist a producer as soon as it misses, without the 100-miss floor.
+
+Rejected as too aggressive. Short outages are common and self-healing, and reassignment is not
+free: it concentrates load on the remaining producers and changes the expected assignment every
+node must agree on. The conjunctive floor plus ratio requirement targets sustained failure only.
+
+### Trailing-window or consecutive-miss detection
+
+Evaluate the thresholds over a rolling window of recent heights, or on a run of consecutive
+misses, instead of over cumulative epoch statistics. This would give a fixed detection bound: a
+producer that fails after a long good stretch would be caught in bounded time rather than after a
+quarter of its good history in further misses (see Detection latency).
+
+Rejected for state and complexity. The cumulative per-epoch counters already exist, are already
+aggregated deterministically, and reset at a boundary every node agrees on. A rolling window is
+new consensus-relevant state that must be carried across the same fork and sync boundaries this
+proposal already has to defend, and the added machinery buys a sharper detection bound that the
+sustained-failure target does not need.
+
+### Decoupled performance accounting
+
+Exclude producers from assignment but keep accruing counterfactual `expected` — or otherwise
+preserve a hypothetical performance record — so that mid-epoch exclusion does not determine the
+end-of-epoch kickout and reward outcome.
+
+Rejected. It requires a second, counterfactual set of counters with no other consumer, maintained
+deterministically for the sole purpose of estimating how a failing producer might have recovered;
+and the boundary decision it would protect is one this proposal is content to let follow the
+observed statistics (see Interaction with end-of-epoch kickout and rewards). A recovery *probe* —
+really offering slots back — is the principled version of this idea and is listed under Future
+possibilities.
+
+### Capping the excluded weight
+
+Disable or cap exclusion when candidates hold too large a fraction of a shard's stake — for
+example, revert to canonical sampling whenever every producer is a candidate, instead of keeping
+one.
+
+Rejected: any cap is one more consensus-relevant threshold to justify, and reverting to canonical
+sampling in the all-candidates case re-includes producers whose chunks are currently not landing
+at all, reproducing the status quo failure exactly where the shard is worst off. Keep-one is the
+smallest rule that keeps the sampler's input non-empty and deterministic.
+
+### No start-of-epoch grace
+
+Rejected: protocol upgrades restart the whole validator set at an epoch boundary. Without a grace
+window a slow network-wide restart would blacklist many producers at once — the exact scenario the
+safety valve exists to survive, and one we would rather not rely on.
+
+### Different thresholds
+
+Alternative values for the 100/80%/1000 triple remain open for discussion; see Parameters for how
+the current values were chosen and Unresolved Issues for their standing. The mechanism is
+insensitive to the specific values in the sense that any conjunctive (absolute floor, ratio) pair
+with a grace window has the same structure and the same safety argument.
+
+## Future possibilities
+
+* **Endorsement-aware signals.** NEP-509 records that chunk validator quality is measured by
+  included chunks rather than endorsements, because the endorsement mask is not header-derived.
+  If that changes, the same in-epoch blacklist structure could act on endorsement statistics and
+  close that gap for chunk validators.
+* **Threshold tuning from mainnet data.** Once the feature is active, observed reassignment rates
+  and safety-valve firings give direct evidence for revisiting the parameters.
+* **Extending to block producers.** Block production has an analogous failure mode. It is out of
+  scope here because block producer assignment interacts with Doomslug consensus, which this
+  proposal deliberately does not touch.
+* **Faster recovery.** Blacklisting is sticky within an epoch, because a blacklisted
+  producer accrues no further `expected`. A probe mechanism that occasionally offers a slot back to
+  a blacklisted producer would let a recovered node return before the epoch boundary.
+* **Caching the resolution.** The read path hits storage on every lookup. A cache layer, or a
+  storage configuration tuned for this column, would reduce that cost.
+
+## Consequences
+
+### Positive
+
+* A shard's chunk production recovers within an epoch instead of at the epoch boundary, bounding
+  the damage of a mid-epoch producer failure to roughly the detection window rather than the
+  remainder of the epoch.
+* Slots are reassigned to the remaining eligible producers by the protocol's existing
+  stake-weighted rule; no new selection concept is introduced.
+* A shard can never be left without an eligible producer.
+* The decision is auditable while the data is retained: the resolved producer for every chunk is
+  persisted (and garbage collected with its block), and the blacklist is reproducible from
+  header-derived state.
+
+### Neutral
+
+* The end-of-epoch kickout rules are unchanged, though their inputs are affected: this proposal
+  changes *assignment* within an epoch, and the statistics freeze that follows exclusion feeds the
+  boundary decision (see Interaction with end-of-epoch kickout and rewards).
+* Chunk validator assignment is unchanged: reassignment changes who produces a chunk, not who
+  validates it.
+* No changes to chunk headers, block headers, transactions, or any contract-visible or RPC schema.
+  Network message variants do change (see Network message compatibility), and RPC endpoints that
+  report producer assignments return the anchored values — their content, not their schema,
+  reflects this proposal.
+* The 80% threshold is deliberately the same as the existing kickout ratio, keeping the mid-epoch
+  and boundary rules aligned on the same statistics.
+
+### Negative
+
+* One additional storage column, with one row per `(block, shard)`. Rows are garbage collected with
+  their block.
+* Per-block work: each processed block seeds its shards' rows, which includes computing the
+  blacklist against the aggregated statistics at its basis.
+* Chunk producer resolution becomes a storage read on the hot signature verification path, where it
+  was previously a pure computation.
+* The protocol's chunk producer for a height is no longer a pure function of `(epoch, shard,
+  height)`. It depends on the anchor, which makes reasoning about historical assignments require
+  chain context.
+* Excluded producers' slots concentrate on the survivors (multiplier `1 / (1 - x)` for excluded
+  stake fraction `x`), which can stress producers already operating near capacity.
+* Exclusion is sticky for the remainder of the epoch regardless of the underlying cause, and by
+  freezing the chunk statistics it locks in the end-of-epoch kickout outcome for producers whose
+  only assignment is the affected shard. This is intentional; see Interaction with end-of-epoch
+  kickout and rewards.
+* Activation changes P2P message variants; see Network message compatibility.
+
+### Backwards Compatibility
+
+There are no changes to chunk headers, block headers, transactions, contract interfaces, or RPC
+schemas.
+
+The release carries two migration steps:
+
+1. **Database version bump.** Introducing `DBCol::ChunkProducers` comes with a `DB_VERSION` bump
+   and its migration, so that existing databases register the new column family and read-only opens
+   of an older database do not fail on a missing column family. The migration creates the column
+   empty; no historical data is backfilled, because rows are only meaningful for blocks processed
+   under the new protocol version, and pre-activation chunks resolve through the canonical sampler.
+2. **Protocol version activation.** Behaviour changes only for epochs whose protocol version has
+   the feature enabled, and resolution is gated on the *chunk's* epoch. At the activation boundary,
+   chunks whose anchor lies in the pre-activation epoch resolve through the canonical sampler,
+   which is exact there because the blacklist is empty in the first blocks of an epoch. Nodes on
+   the old version therefore agree with nodes on the new version up to the activation point, and
+   after it both follow the persisted rows.
+
+Nodes that sync by epoch sync or state sync require the seeding described under Corner cases to
+have valid rows for the blocks they resolve against; this is implemented and covered by tests.
+
+#### Network message compatibility
+
+Activation changes the versions of several validator-to-validator distribution messages. None of
+them are hashed into blocks or chunks, but witness distribution is liveness-critical, so the
+gating rules matter:
+
+* **Partial encoded state witness.** The witness-part message gains a V2 variant carrying the
+  chunk's parent and grandparent hashes (the anchor), transported in new routed-message variants
+  alongside the legacy V1.
+* **Contract distribution.** The chunk contract-accesses and contract-deploys side-channel
+  messages gain V2 variants carrying the same anchor. The contract-code request and response
+  messages are unchanged by this feature.
+* **Partial encoded chunk.** The chunk-parts message gains a V3 variant carrying the anchor. This
+  is the one place a version mismatch is a hard rejection: an anchorless variant for a chunk in an
+  activated epoch is an invalid-header error rather than a silent drop.
+
+The gating rule is uniform: the sender picks the variant by the protocol version of the *chunk's
+epoch*, and the receiver drops a message whose variant does not match its own view of that same
+epoch's protocol version. Because the check is keyed on the message's epoch rather than the node's
+head, a node near the activation boundary legitimately accepts V1 for chunks of the last
+pre-activation epoch and V2 for chunks of the first activated epoch at the same time; mixed-epoch
+operation at the boundary is safe by construction. If the receiver cannot resolve the message's
+epoch yet, the message is not dropped for its version and proceeds to normal validation, which
+fails closed on its own checks.
+
+The version-mismatch drops are silent — these are best-effort distribution channels without
+retransmission — so the practical requirement is the standard one for any protocol upgrade: nodes
+must run a binary that understands the new variants before the activation epoch begins.
+
+## Unresolved Issues (Optional)
+
+* **Parameter values.** The 100-miss floor, the 80% ratio, and the 1000-block grace window were
+  chosen by reasoning — consistency with the existing kickout ratio, upgrade-restart absorption,
+  and noise rejection — and discussed with validators, who accepted them
+  <!-- TODO(author): link the validator feedback venue/thread if public -->. No historical replay
+  of mainnet downtime was performed. Once the mechanism is live, the observability described above
+  (reassignment rates, safety-valve firings) gives direct evidence for revisiting the values.
+* **Read-path cost.** Resolution reads storage on the signature verification path, where it was
+  previously a pure computation. Whether that warrants a cache layer, and at what point, is left to
+  follow-up work rather than settled here; see Future possibilities.
+
+## Changelog
+
+### 1.0.0 - Initial Version
+
+> Placeholder for the context about when and who approved this NEP version.
+
+#### Benefits
+
+> List of benefits filled by the Subject Matter Experts while reviewing this version:
+
+* Benefit 1
+* Benefit 2
+
+#### Concerns
+
+> Template for Subject Matter Experts review for this version:
+> Status: New | Ongoing | Resolved
+
+|   # | Concern | Resolution | Status |
+| --: | :------ | :--------- | -----: |
+|   1 |         |            |        |
+|   2 |         |            |        |
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/neps/nep-0652.md
+++ b/neps/nep-0652.md
@@ -1,9 +1,9 @@
 ---
-NEP: 0
+NEP: 652
 Title: Early Chunk Producer Reassignment
 Authors: Stefan Neamtu <stefan.neamtu@nearone.org>
 Status: Draft
-DiscussionsTo: https://github.com/near/NEPs/pull/0000
+DiscussionsTo: https://github.com/near/NEPs/pull/652
 Type: Protocol
 Version: 1.0.0
 Created: 2026-08-17


### PR DESCRIPTION
Protocol NEP proposing early chunk producer reassignment: removing a persistently failing chunk producer from its shard's chunk production rotation within an epoch, instead of waiting for the existing end-of-epoch kickout, which cannot change the validator set until two epoch boundaries later.

Today a producer that goes offline mid-epoch keeps receiving its share of that shard's chunk slots until the epoch ends. Every one of those slots is a missed chunk, so a shard can spend most of an epoch producing at a fraction of its nominal rate. The existing `chunk_producer_kickout_threshold` is a rotation control, not a liveness control: it decides who keeps a seat two epochs out, not what the shard does for the rest of this one.

The proposal blacklists a producer per shard once it has missed at least 100 chunks in the epoch and its production ratio is below 80%, and reassigns its slots to the remaining eligible producers by stake-weighted sampling over the survivors. A keep-one safety valve guarantees a shard is never left without an eligible producer. A 1000-block start-of-epoch grace window absorbs correlated restarts, primarily protocol upgrades.

Determinism is the core safety argument: the blacklist basis is the anchor's last-final block, which is header-derived, and the resolved producer is persisted and read back verbatim, with reads failing closed rather than falling back.

An excluded producer receives no new slots on that shard, so once its earlier assignments have been counted its production statistics there stop changing unless it returns. Those are the statistics the end-of-epoch kickout and the reward calculation read, so exclusion also settles how the boundary check reads the epoch. That consequence is intended, and the document states the conditions on it: the stake exemption, the guard that keeps one validator when every validator would otherwise be kicked out, and validator selection for the next-but-one epoch succeeding.

Reference implementation is merged in nearcore behind `ProtocolFeature::EarlyKickout` and stabilized at protocol version 87; the PRs are linked in the Reference Implementation section. Mainnet currently runs 86, so the mechanism is not yet active there.
